### PR TITLE
Allow both strings and unicode strings

### DIFF
--- a/performance_platform/core/validators.py
+++ b/performance_platform/core/validators.py
@@ -25,7 +25,7 @@ def value_is_valid_datetime_string(value):
 
 
 def value_is_valid(value):
-    return isinstance(value, (int, unicode, bool))
+    return isinstance(value, (int, basestring, bool))
 
 def key_is_valid(key):
     key = key.lower()

--- a/tests/write/unit_tests.py
+++ b/tests/write/unit_tests.py
@@ -37,9 +37,9 @@ class ValidValuesTestCase(unittest.TestCase):
     def test_values_can_be_integers(self):
         assert_that(value_is_valid(1257), is_(True))
 
-    def test_string_values_can_only_be_unicode_strings(self):
+    def test_string_values_can_strings(self):
         assert_that(value_is_valid(u"1257"), is_(True))
-        assert_that(value_is_valid("1257"), is_(False))
+        assert_that(value_is_valid("1257"), is_(True))
 
     def test_values_can_be_boolean(self):
         assert_that(value_is_valid(True), is_(True))


### PR DESCRIPTION
<a href="https://github.gds/githubmigrator">githubmigrator</a>:

<a href="https://github.com/robyoung">robyoung</a>:
Both can be handled easily. Also, json.load returns strings of type str
for empty strings.

<em><a href="https://github.com/alphagov/backstage/issues/2">Original issue</a> (alphagov/backstage#2) created at 2013-02-27T18:03:51Z.</em>

<em><a href="https://github.gds/gds/backdrop/issues/2">Original issue</a> (gds/backdrop#2) created at 2013-03-01T11:43:43Z.</em>
