### PR TITLE
Rename client creation method.

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -12,7 +12,7 @@ os.environ["FLASK_ENV"] = "test"
 
 
 def before_feature(context, feature):
-    context.client = init_client(feature)
+    context.client = create_client(feature)
 
 
 def before_scenario(context, _):
@@ -25,7 +25,7 @@ def after_feature(context, _):
     context.client.spin_down()
 
 
-def init_client(feature):
+def create_client(feature):
     if 'use_read_api_client' in feature.tags:
         return FlaskTestClient(read_api, DATABASE_NAME)
     if 'use_write_api_client' in feature.tags:


### PR DESCRIPTION
<a href="https://github.gds/githubmigrator">githubmigrator</a>:

<a href="https://github.com/robyoung">robyoung</a>:
@pbadenski
@robyoung

<em><a href="https://github.com/alphagov/backstage/issues/4">Original issue</a> (alphagov/backstage#4) created at 2013-02-28T12:07:46Z.</em>

<em><a href="https://github.gds/gds/backdrop/issues/4">Original issue</a> (gds/backdrop#4) created at 2013-03-01T11:43:46Z.</em>
