### PR TITLE
Remove coupling

### DIFF
--- a/backdrop/core/repository.py
+++ b/backdrop/core/repository.py
@@ -12,9 +12,7 @@ def build_query(**params):
     query = {}
     if 'start_at' in params:
         query = ensure_has_timestamp(query)
-        query['_timestamp'] = {
-            '$gte': params['start_at']
-        }
+        query['_timestamp']['$gte'] = params['start_at']
     if 'end_at' in params:
         query = ensure_has_timestamp(query)
         query['_timestamp']['$lt'] = params['end_at']


### PR DESCRIPTION
**WARNING code written while severely sleep-deprived**

As written, this seems to assume that it will only be queried with a
`start_at` and `end_at` parameters. I don't see any assertion of that
assumption in the code.
