### PR TITLE
Remove CI reporting files before building

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -24,6 +24,8 @@ source $VIRTUALENV_DIR/bin/activate
 pip install -r requirements.txt
 pip install -r requirements_for_tests.txt
 
+rm coverage.xml .coverage nosetests.xml
+
 nosetests -v --with-xunit --with-coverage --cover-package=backdrop --cover-inclusive
 display_result $? 1 "Unit tests"
 python -m coverage.__main__ xml --include=backdrop*


### PR DESCRIPTION
Can cause errors if files are deleted. Specifically, coverage will
attempt to load files that do not exist.
