### PR TITLE
Fix period and group by

### DIFF
--- a/backdrop/core/bucket.py
+++ b/backdrop/core/bucket.py
@@ -93,7 +93,7 @@ class Bucket(object):
                 week_start_at = item.pop("_week_start_at")
                 if week_start_at.weekday() is not 0:
                     raise ValueError('Weeks MUST start on Monday. '
-                                     'Corrupt Data')
+                                     'Corrupt Data: ' + str(week_start_at))
                 start_at = utc(week_start_at)
                 item.update({
                     "_start_at": start_at,

--- a/tests/core/test_bucket.py
+++ b/tests/core/test_bucket.py
@@ -361,7 +361,7 @@ class TestBucket(unittest.TestCase):
             limit=1,
             collect=[])
 
-    def test_blows_up_when_weeks_dont_start_on_monday(self):
+    def test_blows_up_when_weeks_do_not_start_on_monday(self):
         multi_group_results = [
             {
                 "is": "Monday",
@@ -390,4 +390,6 @@ class TestBucket(unittest.TestCase):
             self.bucket.query(period='week', group_by='d')
             assert_that(False)
         except ValueError as e:
-            assert_that(str(e), is_("Weeks MUST start on Monday. Corrupt Data"))
+            assert_that(str(e), is_(
+                "Weeks MUST start on Monday. Corrupt Data: 2013-04-09 00:00:00"
+            ))


### PR DESCRIPTION
Making this blow up loudly instead of fail silently. Should never happen as long as data is only imported via the API and not directly. However we should still fix it eventually.
