### PR TITLE
Fix typo on post deploy hook

### DIFF
--- a/hooks/post_deploy
+++ b/hooks/post_deploy
@@ -1,4 +1,4 @@
-#!/usr/local/env bash
+#!/usr/bin/env bash
 
 BACKDROP_APP=$(echo $GOVUK_APP_NAME | cut -d . -f 1)
 


### PR DESCRIPTION
env does not live in /usr/local
