### PR TITLE
Refactor logging and change log file name

### DIFF
--- a/backdrop/core/log_handler.py
+++ b/backdrop/core/log_handler.py
@@ -8,3 +8,12 @@ def get_log_file_handler(path, log_level=logging.DEBUG):
         "%(asctime)s [%(levelname)s] -> %(message)s"))
     handler.setLevel(log_level)
     return handler
+
+
+def set_up_logging(app, name, env):
+    log_level = logging._levelNames[app.config['LOG_LEVEL']]
+    app.logger.addHandler(
+        get_log_file_handler("log/%s.log" % env, log_level)
+    )
+    app.logger.setLevel(log_level)
+    app.logger.info("Backdrop %s API logging started" % name)

--- a/backdrop/read/api.py
+++ b/backdrop/read/api.py
@@ -1,25 +1,19 @@
 import datetime
 import json
-import logging
 from os import getenv
 
 from dateutil import parser
 from flask import Flask, jsonify, request
 import pytz
-from backdrop.core.log_handler import get_log_file_handler
+
 
 from .validation import validate_request_args
-from ..core import database
+from ..core import database, log_handler
 from ..core.bucket import Bucket
 
 
 def setup_logging():
-    log_level = logging._levelNames[app.config['LOG_LEVEL']]
-    env = getenv("GOVUK_ENV", "development")
-    app.logger.addHandler(get_log_file_handler("log/%s.read.log" % env,
-                                               log_level))
-    app.logger.setLevel(log_level)
-    app.logger.info("Backdrop read API logging started")
+    log_handler.set_up_logging(app, "read", getenv("GOVUK_ENV", "development"))
 
 
 app = Flask(__name__)
@@ -84,6 +78,7 @@ def exception_handler(e):
     app.logger.exception(e)
     return jsonify(status='error', message=''), e.code
 
+
 @app.route('/_status')
 def health_check():
     if db.alive():
@@ -91,6 +86,7 @@ def health_check():
     else:
         return jsonify(status='error',
                        message='cannot connect to database'), 500
+
 
 @app.route('/<bucket_name>', methods=['GET'])
 def query(bucket_name):

--- a/backdrop/write/api.py
+++ b/backdrop/write/api.py
@@ -1,21 +1,15 @@
-import logging
 from os import getenv
 
 from flask import Flask, request, jsonify
-from backdrop.core import records
-from backdrop.core.log_handler import get_log_file_handler
 
 from .validation import validate_post_to_bucket
-from ..core import database
+from ..core import database, log_handler, records
 from ..core.bucket import Bucket
 
 
-def setup_logger():
-    log_level = logging._levelNames[app.config['LOG_LEVEL']]
-    app.logger.addHandler(
-        get_log_file_handler("log/%s.write.log" % environment(), log_level))
-    app.logger.setLevel(log_level)
-    app.logger.info("Logging for Backdrop Write API started")
+def setup_logging():
+    log_handler.set_up_logging(app, "write",
+                               getenv("GOVUK_ENV", "development"))
 
 
 def environment():
@@ -36,7 +30,7 @@ db = database.Database(
 )
 
 
-setup_logger()
+setup_logging()
 
 
 @app.before_request


### PR DESCRIPTION
- Move duplicate setup into log_handler module
- Use [environment].log for both read and write
  When deployed read and write are their own applications so there is no
  overlap.
