### PR TITLE
Both 'start_at' and 'end_at' are required

### DIFF
--- a/backdrop/read/validation.py
+++ b/backdrop/read/validation.py
@@ -53,6 +53,14 @@ class DatetimeValidator(Validator):
                                % context['param_name'])
 
 
+class PeriodQueryValidator(Validator):
+    def validate(self, request_args, context):
+        if 'start_at' in request_args or 'end_at' in request_args:
+            if not ('start_at' in request_args and 'end_at' in request_args):
+                self.add_error("both 'start_at' and 'end_at' are required "
+                               "for a period query")
+
+
 class PositiveIntegerValidator(Validator):
     def validate(self, request_args, context):
         if context['param_name'] in request_args:
@@ -181,6 +189,7 @@ class MondayValidator(Validator):
 def validate_request_args(request_args):
     validators = [
         ParameterValidator(request_args),
+        PeriodQueryValidator(request_args),
         DatetimeValidator(request_args, param_name='start_at'),
         DatetimeValidator(request_args, param_name='end_at'),
         FilterByValidator(request_args),

--- a/features/read_api/filter.feature
+++ b/features/read_api/filter.feature
@@ -4,16 +4,12 @@ Feature: filtering queries for read api
     Scenario: querying for data ON or AFTER a certain point
         Given "licensing.json" is in "foo" bucket
          when I go to "/foo?start_at=2012-12-13T01:01:01%2B00:00"
-         then I should get back a status of "200"
-          and the JSON should have "4" results
-          and the "1st" result should be "{"_timestamp": "2012-12-13T01:01:01+00:00", "authority": "Westminster", "interaction": "success", "licence_name": "Temporary events notice", "_id": "1236", "type": "success"}"
+         then I should get back a status of "400"
 
     Scenario: querying for data BEFORE a certain point
         Given "licensing.json" is in "foo" bucket
          when I go to "/foo?end_at=2012-12-12T01:01:02%2B00:00"
-         then I should get back a status of "200"
-          and the JSON should have "2" results
-          and the "1st" result should be "{"_timestamp": "2012-12-12T01:01:01+00:00", "licence_name": "Temporary events notice", "interaction": "success", "authority": "Westminster", "type": "success", "_id": "1234"}"
+         then I should get back a status of "400"
 
     Scenario: querying for data between two points
         Given "licensing.json" is in "foo" bucket

--- a/tests/read/test_read_api.py
+++ b/tests/read/test_read_api.py
@@ -30,24 +30,19 @@ class ReadApiTestCase(unittest.TestCase):
         mock_query.assert_called_with(group_by=u'zombies')
 
     @patch('backdrop.core.bucket.Bucket.query')
-    def test_start_at_query_is_executed(self, mock_query):
+    def test_period_query_is_executed(self, mock_query):
         mock_query.return_value = None
-        expected_start_at = datetime.datetime(2012, 12, 12, 8, 12, 43,
+        expected_start_at = datetime.datetime(2012, 12, 5, 8, 12, 43,
                                               tzinfo=pytz.UTC)
-        self.app.get(
-            '/foo?start_at=' + urllib.quote("2012-12-12T08:12:43+00:00")
-        )
-        mock_query.assert_called_with(start_at=expected_start_at)
-
-    @patch('backdrop.core.bucket.Bucket.query')
-    def test_end_at_query_is_executed(self, mock_query):
-        mock_query.return_value = None
         expected_end_at = datetime.datetime(2012, 12, 12, 8, 12, 43,
                                             tzinfo=pytz.UTC)
         self.app.get(
-            '/foo?end_at=' + urllib.quote("2012-12-12T08:12:43+00:00")
+            '/foo?start_at=' + urllib.quote("2012-12-05T08:12:43+00:00") +
+            '&end_at=' + urllib.quote("2012-12-12T08:12:43+00:00")
         )
-        mock_query.assert_called_with(end_at=expected_end_at)
+        mock_query.assert_called_with(
+            start_at=expected_start_at, end_at=expected_end_at
+        )
 
     @patch('backdrop.core.bucket.Bucket.query')
     def test_group_by_with_period_is_executed(self, mock_query):

--- a/tests/read/test_validation.py
+++ b/tests/read/test_validation.py
@@ -8,25 +8,33 @@ from tests.support.validity_matcher import is_invalid_with_message, is_valid
 class TestRequestValidation(TestCase):
     def test_queries_with_badly_formatted_start_at_are_disallowed(self):
         assert_that(
-            validate_request_args({'start_at': 'i am not a time'}),
+            validate_request_args({
+                'start_at': 'i am not a time',
+                'end_at': 'i am not a time'
+            }),
             is_invalid_with_message("start_at is not a valid datetime")
         )
 
     def test_queries_with_well_formatted_start_at_are_allowed(self):
         validation_result = validate_request_args({
-            'start_at': '2000-02-02T00:02:02+00:00'
+            'start_at': '2000-02-02T00:02:02+00:00',
+            'end_at': '2000-02-09T00:02:02+00:00'
         })
         assert_that(validation_result, is_valid())
 
     def test_queries_with_badly_formatted_end_at_are_disallowed(self):
         assert_that(
-            validate_request_args({'end_at': 'foo'}),
+            validate_request_args({
+                'start_at': '2000-02-02T00:02:02+00:00',
+                'end_at': 'foo'
+            }),
             is_invalid_with_message("end_at is not a valid datetime")
         )
 
     def test_queries_with_well_formatted_end_at_are_allowed(self):
         validation_result = validate_request_args({
-            'end_at': '2000-02-02T00:02:02+00:00'
+            'start_at': '2000-02-02T00:02:02+00:00',
+            'end_at': '2000-02-09T00:02:02+00:00'
         })
         assert_that(validation_result, is_valid())
 
@@ -224,7 +232,8 @@ class TestRequestValidation(TestCase):
 
     def test_queries_with_non_existent_dates_are_disallowed(self):
         validation_result = validate_request_args({
-            'start_at': '2013-13-70T00:00:00Z'
+            'start_at': '2013-13-70T00:00:00Z',
+            'end_at': '2013-12-70T00:00:00Z'
         })
 
         assert_that(validation_result, is_invalid_with_message(

--- a/tests/read/test_validation_of_queries_accessing_raw_data.py
+++ b/tests/read/test_validation_of_queries_accessing_raw_data.py
@@ -46,13 +46,15 @@ class TestValidationOfQueriesAccessingRawData(TestCase):
     def test_that_query_starting_on_midnight_is_allowed(self):
         result = validate_request_args({
             'group_by': 'some_key',
-            'start_at': '2013-01-01T00:00:00+00:00'
+            'start_at': '2013-01-01T00:00:00+00:00',
+            'end_at': '2013-01-08T00:00:00+00:00'
         })
         assert_that(result, is_valid())
 
     def test_that_query_ending_on_midnight_is_allowed(self):
         result = validate_request_args({
             'group_by': 'some_key',
+            'start_at': '2013-01-24T00:00:00+00:00',
             'end_at': '2013-01-31T00:00:00+00:00'
         })
         assert_that(result, is_valid())
@@ -86,7 +88,8 @@ class TestValidationOfQueriesAccessingRawData(TestCase):
     def test_that_start_at_with_time_other_than_midnight_is_disallowed(self):
         validation_result = validate_request_args({
             'group_by': 'some_key',
-            'start_at': '2013-04-01T00:00:01Z'
+            'start_at': '2013-04-01T00:00:01Z',
+            'end_at': '2013-04-08T00:00:01Z'
         })
         assert_that(validation_result, is_invalid_with_message(
             'start_at must be midnight'))
@@ -94,7 +97,28 @@ class TestValidationOfQueriesAccessingRawData(TestCase):
     def test_that_end_at_with_time_other_than_midnight_is_disallowed(self):
         validation_result = validate_request_args({
             'group_by': 'some_key',
-            'end_at': '2013-04-01T00:00:01Z'
+            'start_at': '2013-04-01T00:00:00Z',
+            'end_at': '2013-04-08T00:00:01Z'
         })
         assert_that(validation_result, is_invalid_with_message(
             'end_at must be midnight'))
+
+    def test_that_start_at_alone_is_disallowed(self):
+        validation_result = validate_request_args({
+            'period': 'week',
+            'start_at': '2013-04-01T00:00:00Z'
+        })
+        assert_that(validation_result,
+                    is_invalid_with_message(
+                        "both 'start_at' and 'end_at' are required for "
+                        "a period query"))
+
+    def test_that_end_at_alone_is_disallowed(self):
+        validation_result = validate_request_args({
+            'period': 'week',
+            'end_at': '2013-04-01T00:00:00Z'
+        })
+        assert_that(validation_result,
+                    is_invalid_with_message(
+                        "both 'start_at' and 'end_at' are required for "
+                        "a period query"))


### PR DESCRIPTION
It shouldn't be possible to query for open-ended periods. It can be used to identify individual licence events.
