### PR TITLE
Fix bootstrapping a clean VM

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -20,6 +20,10 @@ function display_result {
 basedir=$(dirname $0)
 venvdir=~/.virtualenvs/$(basename $(cd $(dirname $0) && pwd -P))
 
+if [ ! -d $venvdir ]; then
+  virtualenv $venvdir
+fi
+
 source "$venvdir/bin/activate"
 
 pip install -r requirements_for_tests.txt


### PR DESCRIPTION
If the virtualenv doesn't exist, we should create it.

I destroyed my VM, recreated it and had a problem.

This fixes said problem.
