### PR TITLE
Clean output and setup logging for behave tests

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -1,5 +1,7 @@
+import logging
 import os
 import sys
+from backdrop.core.log_handler import get_log_file_handler
 from features.support.splinter_client import SplinterClient
 
 sys.path.append(
@@ -14,6 +16,16 @@ from backdrop.read import api as read_api
 from backdrop.write import api as write_api
 # pick one for test configuration, if they don't match things will fail
 from backdrop.write.config import test as config
+
+
+handler = logging.FileHandler('log/behave.log')
+handler.setFormatter(logging.Formatter(
+    "%(asctime)s [%(levelname)s - %(name)s - %(filename)s:%(lineno)d] "
+    "-> %(message)s"))
+
+
+log = logging.getLogger()
+log.addHandler(handler)
 
 
 def before_feature(context, feature):

--- a/features/support/http_test_client.py
+++ b/features/support/http_test_client.py
@@ -42,6 +42,7 @@ class HTTPTestClient(object):
         return subprocess.Popen(
             ["python", "start.py", api, self.APP_PORTS[api]],
             preexec_fn=os.setsid,
+            stderr=subprocess.STDOUT, stdout=subprocess.PIPE
         )
 
     def read_url(self, url):

--- a/features/support/splinter_client.py
+++ b/features/support/splinter_client.py
@@ -6,10 +6,6 @@ from splinter import Browser
 from features.support.http_test_client import HTTPTestClient
 
 
-logging.getLogger('selenium.webdriver.remote.remote_connection')\
-    .setLevel(logging.WARNING)
-
-
 class SplinterClient(object):
 
     def __init__(self, database_name):


### PR DESCRIPTION
Setup behave to avoid printing of additional noise to stdout, which makes behave output hard to read:
- write logs coming from behave process to file log/behave.log
- discard stdout from child processes
