### PR TITLE
Fall back to path for write api errors

### DIFF
--- a/backdrop/write/api.py
+++ b/backdrop/write/api.py
@@ -53,8 +53,9 @@ def exception_handler(e):
     bucket_name = getattr(g, 'bucket_name', request.path)
     statsd.incr("write.error", bucket=bucket_name)
 
-    code = getattr(e, 'code', None)
-    name = getattr(e, 'name', None)
+    code = getattr(e, 'code', 500)
+    name = getattr(e, 'name', "Internal Error")
+
     return jsonify(status='error', message=name), code
 
 


### PR DESCRIPTION
Use the request path instead of the bucket name for errors if the bucket
name has not been set.

@maxfliri
@robyoung
