### PR TITLE
Allow raw queries to annotations bucket

### DIFF
--- a/backdrop/read/config/development.py
+++ b/backdrop/read/config/development.py
@@ -3,5 +3,6 @@ MONGO_HOST = 'localhost'
 MONGO_PORT = 27017
 LOG_LEVEL = "DEBUG"
 RAW_QUERIES_ALLOWED = {
-    "licensing_journey": True
+    "licensing_journey": True,
+    "government_annotations": True,
 }


### PR DESCRIPTION
This bucket holds the annotations for the insidegov dashboard.
