### PR TITLE
Enable user to all buckets with wildcard permission

### DIFF
--- a/backdrop/write/permissions.py
+++ b/backdrop/write/permissions.py
@@ -3,4 +3,11 @@ class Permissions(object):
         self._permissions = permissions
 
     def allowed(self, user, bucket_name):
+        return self._has_permission(user, bucket_name) \
+            or self._has_wildcard_permission(user)
+
+    def _has_wildcard_permission(self, user):
+        return self._has_permission(user, "*")
+
+    def _has_permission(self, user, bucket_name):
         return bucket_name in self._permissions.get(user, [])

--- a/tests/write/test_permissions.py
+++ b/tests/write/test_permissions.py
@@ -25,3 +25,11 @@ class PermissionsTestCase(unittest.TestCase):
         })
 
         assert_that(permissions.allowed("userone", "mybucket"), is_(True))
+
+    def test_return_true_for_user_with_wildcard_permission(self):
+        permissions = Permissions({
+            "userone": ["*"]
+        })
+
+        assert_that(permissions.allowed("userone", "any_bucket"), is_(True))
+        assert_that(permissions.allowed("userone", "other_bucket"), is_(True))


### PR DESCRIPTION
This change allows enabling a user to all buckets using the special wildcard permission "*".

This is something I added just to make development easier; I think it might be useful for test user in preview too. Please have a look: if you think it's something useful we can merge it to master.
