### PR TITLE
Disable travis emails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,5 @@ after_script:
 branches:
   except:
     - release
+notifications:
+  email: false


### PR DESCRIPTION
I don't think this is generally useful - we use the status indicator
on github pull requests to determine whether we've broken anything?
