### PR TITLE
Pull in EVL total numbers from the spreadsheet

### DIFF
--- a/backdrop/contrib/evl_upload_filters.py
+++ b/backdrop/contrib/evl_upload_filters.py
@@ -96,8 +96,9 @@ def service_failures(sheets):
 
 def channel_volumetrics(rows):
     rows = list(rows)
-    yield ["_timestamp", "_id", "successful_agent", "successful_ivr",
-           "successful_web"]
+    yield ["_timestamp", "_id",
+           "successful_agent", "successful_ivr", "successful_web",
+           "total_agent", "total_ivr", "total_web"]
 
     for column in range(1, 8):
         all = rows[5][column]
@@ -106,12 +107,18 @@ def channel_volumetrics(rows):
             return
 
         date = rows[1][column]
-        agent = rows[2][column]
-        ivr = rows[3][column]
-        web = rows[4][column]
 
-        yield [date, parse_time_as_utc(date).date().isoformat(), agent, ivr,
-               web]
+        agent_successful = rows[2][column]
+        ivr_successful = rows[3][column]
+        web_successful = rows[4][column]
+
+        agent_total = rows[6][column]
+        ivr_total = rows[7][column]
+        web_total = rows[8][column]
+
+        yield [date, parse_time_as_utc(date).date().isoformat(),
+               agent_successful, ivr_successful, web_successful,
+               agent_total, ivr_total, web_total]
 
 
 def customer_satisfaction(rows):

--- a/features/contrib/evl_upload.feature
+++ b/features/contrib/evl_upload.feature
@@ -48,8 +48,8 @@ Feature: EVL Upload
         then the platform should have "2" items stored in "evl_channel_volumetrics"
          and the "evl_channel_volumetrics" bucket should have items:
              """
-             {"_timestamp": "2013-07-29T00:00:00+00:00", "_id": "2013-07-29", "successful_agent": 100.0, "successful_ivr": 101.0, "successful_web": 102.0}
-             {"_timestamp": "2013-07-30T00:00:00+00:00", "_id": "2013-07-30", "successful_agent": 101.0, "successful_ivr": 102.0, "successful_web": 103.0}
+             {"_timestamp": "2013-07-29T00:00:00+00:00", "_id": "2013-07-29", "successful_agent": 100.0, "successful_ivr": 101.0, "successful_web": 102.0, "total_agent": 200.0, "total_ivr": 201.0, "total_web": 202.0}
+             {"_timestamp": "2013-07-30T00:00:00+00:00", "_id": "2013-07-30", "successful_agent": 101.0, "successful_ivr": 102.0, "successful_web": 103.0, "total_agent": 201.0, "total_ivr": 202.0, "total_web": 203.0}
              """
 
     Scenario: Upload customer satisfaction

--- a/tests/contrib/test_evl_upload_filters.py
+++ b/tests/contrib/test_evl_upload_filters.py
@@ -83,13 +83,17 @@ class EVLServiceVolumetrics(unittest.TestCase):
             [["IVR successful", 30, 40, '']] + \
             [["WEB successful", 40, 50, '']] + \
             [["Total successful all channels", 40, 50, 0]] + \
+            [["Agent total", 60, 30, '']] + \
+            [["IVR total", 20, 40, '']] + \
+            [["Web total", 70, 10, '']] + \
+            [["Total all channels", 150, 80, 0]] + \
             self.ignore_rows(17)
 
         data = list(channel_volumetrics(volumetrics_raw_data))
 
-        assert_that(data, is_([["_timestamp", "_id", "successful_agent", "successful_ivr", "successful_web"],
-                               [monday, "2013-07-29", 10, 30, 40],
-                               [tuesday, "2013-07-30", 20, 40, 50]]))
+        assert_that(data, is_([["_timestamp", "_id", "successful_agent", "successful_ivr", "successful_web", "total_agent", "total_ivr", "total_web"],
+                               [monday, "2013-07-29", 10, 30, 40, 60, 20, 70],
+                               [tuesday, "2013-07-30", 20, 40, 50, 30, 40, 10]]))
 
     def test_converts_customer_satisfaction_raw_data_to_normalised_data(self):
         may = d_tz(2013, 5, 1)


### PR DESCRIPTION
Previously, we were only taking the successful numbers. We need the
totals in order to calculate completion rate.
