### PR TITLE
Make backdrop work with python 2.6

### DIFF
--- a/backdrop/core/nested_merge.py
+++ b/backdrop/core/nested_merge.py
@@ -105,7 +105,7 @@ def apply_collect_to_group(group, collect):
 def collect_key(key, method):
     if method == 'default':
         method = 'set'
-    return '{}:{}'.format(key, method)
+    return '{0}:{1}'.format(key, method)
 
 
 def collect_value(group, key, method):

--- a/tests/read/test_weekly_grouped_data.py
+++ b/tests/read/test_weekly_grouped_data.py
@@ -16,7 +16,7 @@ class TestWeeklyGroupedData(unittest.TestCase):
         stub_document = {"_subgroup": []}
         data = PeriodGroupedData([stub_document], WEEK)
         another_data = data.data()
-        assert_is_instance(another_data, tuple)
+        ok_(isinstance(another_data, tuple))
 
     def test_adding_multiple_mongo_documents(self):
         stub_document_1 = {


### PR DESCRIPTION
- Use format indexes
- Do not use assertIsInstance
