### PR TITLE
Drop collections when replicating db

### DIFF
--- a/replicate-db.sh
+++ b/replicate-db.sh
@@ -56,10 +56,10 @@ tar xzvf $FILENAME
 
 if [ -z "$2" ]; then
 	pushd ../puppet/development
-	vagrant ssh -c "cd /var/govuk/backdrop && mongorestore ${DUMPDIR}"
+	vagrant ssh -c "cd /var/govuk/backdrop && mongorestore --drop ${DUMPDIR}"
 	popd
 else
-	mongorestore -h $DESTINATION_HOST $DUMPDIR
+	mongorestore --drop -h $DESTINATION_HOST $DUMPDIR
 fi
 
 # cleanup locally


### PR DESCRIPTION
By default `mongorestore` appends data to collections if they already
exist. This flag ensures the collection is dropped.
