### PR TITLE
Use clamdscan instead of clamscan

### DIFF
--- a/backdrop/write/scanned_file.py
+++ b/backdrop/write/scanned_file.py
@@ -30,7 +30,7 @@ class ScannedFile(object):
             self._file_path)
 
     def _clamscan(self, filename):
-        return bool(subprocess.call(["clamscan", filename]))
+        return bool(subprocess.call(["clamdscan", filename]))
 
     def _clean_up(self):
         # Remove temporary file


### PR DESCRIPTION
It turns out clam scan runs about 10^6 faster if we hit the (already running) clamav-daemon rather than starting clamav up with its massive db etc every time

![](http://i.imgur.com/EU4bUge.gif)
