### PR TITLE
Adding in @tags field to JSON output

### DIFF
--- a/backdrop/core/log_handler.py
+++ b/backdrop/core/log_handler.py
@@ -15,6 +15,7 @@ def get_log_file_handler(path, log_level=logging.DEBUG):
 def get_json_log_handler(path):
     handler = FileHandler(path)
     formatter = LogstashFormatter()
+    formatter.defaults['@tags'] = ['application']
     handler.setFormatter(formatter)
     return handler
 

--- a/tests/core/test_json_logging.py
+++ b/tests/core/test_json_logging.py
@@ -26,5 +26,10 @@ class TestJsonLogging(unittest.TestCase):
             '@message': 'Writing out JSON formatted logs m8'
         }))
 
+        assert_that(data, has_entries({
+            '@tags': ['application']
+        }))
+
         # Only remove file if assertion passes
         os.remove('log/json_test.log.json')
+        os.remove('log/json_test.log')


### PR DESCRIPTION
- All messages from backdrop will be tagged as 'appclication' to help distinguish from e.g. gunicorn, nginx, requests etc
