### PR TITLE
Use a forked version of python-logstash-formatter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ Flask==0.10.1
 Flask-FeatureFlags==0.3
 gunicorn==18.0
 invoke
-logstash-formatter==0.5.5
 pip==1.4.1
 pymongo==2.6.1
 python-dateutil==2.1
@@ -11,3 +10,4 @@ pytz==2013b
 rauth==0.5.4
 statsd==2.0.3
 xlrd==0.9.2
+-e git+https://github.com/alphagov/python-logstash-formatter.git@fix-docstring#egg=logstash_formatter


### PR DESCRIPTION
The constructor signature is broken in the released version.
