### PR TITLE
Add request method and url to response log

### DIFF
--- a/backdrop/core/log_handler.py
+++ b/backdrop/core/log_handler.py
@@ -40,6 +40,10 @@ def create_request_logger(app):
 
 def create_response_logger(app):
     def log_response(response):
-        app.logger.info("response: %s" % response.status)
+        app.logger.info(
+            "response: %s - %s - %s" % (
+                request.method, request.url, response.status
+            )
+        )
         return response
     return log_response


### PR DESCRIPTION
At the moment we can't relate the response to a request.
