### PR TITLE
Abort start-app.sh script if any command fails.

### DIFF
--- a/start-app.sh
+++ b/start-app.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 venvdir=~/.virtualenvs/$(basename $(cd $(dirname $0) && pwd -P))
 


### PR DESCRIPTION
If the virtualenv isn't created the "pip install" command should not be
run as it could pollute your setup.
