### PR TITLE
Service failure filter should expect None not ''

### DIFF
--- a/backdrop/contrib/evl_upload_filters.py
+++ b/backdrop/contrib/evl_upload_filters.py
@@ -83,7 +83,7 @@ def service_failures(sheets):
 
     for row in rows[6:]:
         description = row[0]
-        if len(description) == 0:
+        if description is None:
             return
 
         reason_code = int(row[1])

--- a/tests/contrib/test_evl_upload_filters.py
+++ b/tests/contrib/test_evl_upload_filters.py
@@ -36,7 +36,7 @@ class EVLServiceVolumetrics(unittest.TestCase):
             [["Failure 1", 0, 10, 0, 2]] +
             [["Failure 2", 1, 20, 0, 3]] +
             [["Failure 3", 2, 30, 0, 4]] +
-            [["", "Blank first column means end of failures list"]]
+            [[None, "None in first column means end of failures list"]]
         ]
 
         data = list(service_failures(failures_raw_data))
@@ -60,7 +60,7 @@ class EVLServiceVolumetrics(unittest.TestCase):
             self.ignore_rows(4) +
             [["No tax-disc failure", 0, '', 0, 2]] +
             [["No sorn failure", 1, 20, 0, '']] +
-            [["", "Blank first column means end of failures list"]]
+            [[None, "None in first column means end of failures list"]]
         ]
 
         data = list(service_failures(failures_raw_data))


### PR DESCRIPTION
We made a change to the parsing of excel sheets so that empty cells we
parsed as None rather than an empty string. This bug was not picked up
as there are no integration tests between the sheet parser and the
filter.
