### PR TITLE
Don't overwrite the virtualenv if exists

### DIFF
--- a/start-app.sh
+++ b/start-app.sh
@@ -2,7 +2,9 @@
 
 venvdir=~/.virtualenvs/$(basename $(cd $(dirname $0) && pwd -P))
 
-virtualenv --no-site-packages "$venvdir"
+if [ ! -d "${venvdir}" ]; then
+    virtualenv --no-site-packages "$venvdir"
+fi
 
 source "$venvdir/bin/activate"
 


### PR DESCRIPTION
If you run `bowl backdrop_read` and `bowl backdrop_write`
simultaneously both processes were trying to create the virtualenv. This
caused file locking errors on the Python executable.

(This also fixes the `bowl backdrop` which was failing)
