### PR TITLE
Use a different virtualenv for each backdrop app

### DIFF
--- a/start-app.sh
+++ b/start-app.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-venvdir=~/.virtualenvs/$(basename $(cd $(dirname $0) && pwd -P))
+venvdir=~/.virtualenvs/$(basename $(cd $(dirname $0) && pwd -P))-$1-$2
 
 if [ ! -d "${venvdir}" ]; then
     virtualenv --no-site-packages "$venvdir"


### PR DESCRIPTION
If backdrop_read, backdrop_write, backdrop_admin use the same virtualenv
(~/.virtualenvs/backdrop) there's a race condition the first time `bowl
backdrop` is called (when no virtualenv exists) as they all try to run
virtualenv and pip install at the same time.

This commit gives them all unique virtualenv directories.
