### PR TITLE
Rename bucket to bucket_name in index.html

### DIFF
--- a/backdrop/write/templates/index.html
+++ b/backdrop/write/templates/index.html
@@ -13,11 +13,11 @@
                         <a href="mailto:performance-platform@digital.cabinet-office.gov.uk">contact the Performance Platform team</a>.
                     </p>
                     <ul id="bucket-list">
-                        {% for bucket in user_config.buckets %}
+                        {% for bucket_name in user_config.buckets %}
                         <li>
-                            <h3>{{ bucket }}</h3>
-                            <p><a href="{{ url_for('upload', bucket_name=bucket) }}">
-                                Upload a CSV to the {{ bucket }} bucket
+                            <h3>{{ bucket_name }}</h3>
+                            <p><a href="{{ url_for('upload', bucket_name=bucket_name) }}">
+                                Upload a CSV to the {{ bucket_name }} bucket
                             </a></p>
                         </li>
                         {% endfor %}


### PR DESCRIPTION
We were confused that a bucket was a Bucket object, when it was in fact
a string bucket_name. It was sufficiently confusing that we doubted our
own (very simple) code.
