### PR TITLE
Switch migrations to use Repository as appropriate

### DIFF
--- a/backdrop/core/database.py
+++ b/backdrop/core/database.py
@@ -131,7 +131,10 @@ class Repository(object):
 
         self._validate_sort(sort)
 
-        return self._mongo_driver.find(query.to_mongo_query(), sort, limit)
+        is_class = hasattr(query, 'to_mongo_query')
+        mongo_query = query.to_mongo_query() if is_class else query
+
+        return self._mongo_driver.find(mongo_query, sort, limit)
 
     def group(self, group_by, query, sort=None, limit=None, collect=None):
         if sort:

--- a/migrations/001_add_week_start.py
+++ b/migrations/001_add_week_start.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 def up(db):
     for name in db.collection_names():
         log.info("Migrating collection: {0}".format(name))
-        collection = db.get_collection(name)
+        collection = db.get_repository(name)
         query = {
             "_timestamp": {"$exists": True},
             "_week_start_at": {"$exists": False}

--- a/migrations/002_add_month_start.py
+++ b/migrations/002_add_month_start.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 def up(db):
     for name in db.collection_names():
         log.info("Migrating collection: {0}".format(name))
-        collection = db.get_collection(name)
+        collection = db.get_repository(name)
         query = {
             "_timestamp": {"$exists": True},
             "_month_start_at": {"$exists": False}

--- a/migrations/005_add_hour_and_day_start.py
+++ b/migrations/005_add_hour_and_day_start.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 def up(db):
     for name in db.collection_names():
         log.info("Migrating collection: {0}".format(name))
-        collection = db.get_collection(name)
+        collection = db.get_repository(name)
         query = {
             "_timestamp": {"$exists": True},
             "_day_start_at": {"$exists": False}

--- a/migrations/007_add_quarter_start.py
+++ b/migrations/007_add_quarter_start.py
@@ -12,7 +12,7 @@ log = logging.getLogger(__name__)
 def up(db):
     for name in db.collection_names():
         log.info("Migrating collection: {0}".format(name))
-        collection = db.get_collection(name)
+        collection = db.get_repository(name)
         query = {
             "_timestamp": {"$exists": True},
             "_quarter_start_at": {"$exists": False}

--- a/tests/core/integration/test_database_integration.py
+++ b/tests/core/integration/test_database_integration.py
@@ -733,6 +733,33 @@ class TestRepositoryIntegration_Sorting(RepositoryIntegrationTest):
         assert_that(result, has_item(has_entry("_count", 1)))
 
 
+class TestRepositoryIntegration_Finding(RepositoryIntegrationTest):
+    def test_query_class(self):
+        self.mongo_collection.save({"foo": 1})
+        self.mongo_collection.save({"foo": 2})
+        self.mongo_collection.save({"foo": 3})
+
+        result = self.repo.find(Query.create())
+
+        assert_that(list(result), contains(
+            has_entry("foo", 1),
+            has_entry("foo", 2),
+            has_entry("foo", 3),
+        ))
+
+    def test_query_map(self):
+        self.mongo_collection.save({"foo": 1})
+        self.mongo_collection.save({"foo": 2})
+        self.mongo_collection.save({"foo": 3})
+
+        result = self.repo.find({"foo": 1})
+
+        assert_that(result.count(), equal_to(1))
+        assert_that(list(result), contains(
+            has_entry("foo", 1),
+        ))
+
+
 class TestDatabase(unittest.TestCase):
     def setUp(self):
         self.db = Database('localhost', 27017, 'backdrop_test')


### PR DESCRIPTION
In order for the _updated_at field to be correctly applied the
migrations that operate on buckets need to be using the Repository class
to modify the data in mongodb.

The Repository find() method had to be modified to be able to use both
classes that provide a to_mongo_query() method (the Query class) or a
Dictionary as would be usual with a mongodb find.

I have added some tests to make sure that Repository will work correctly
when accepting both types of find() argument.
