### PR TITLE
Show ‘last updated’ to clarify bucket check message

### DIFF
--- a/backdrop/read/api.py
+++ b/backdrop/read/api.py
@@ -107,7 +107,7 @@ def bucket_health():
 
 def _bucket_message(buckets):
     message = ', '.join(
-        '%s (%s)' % (bucket['name'],
+        '%s (last updated: %s)' % (bucket['name'],
                      bucket['last_updated'])
         for bucket in buckets)
     return message


### PR DESCRIPTION
Such alerts, much warn, very knowledge 

![](http://24.media.tumblr.com/1e759463702dc99832a5bd4c8a7500c7/tumblr_mxe3ixqlf21sm8e0ho1_500.jpg)
- We should extend this at some point to display the difference between `last_updated` and expected age
