### PR TITLE
Exclude transient directories from PEP8 check

### DIFF
--- a/pep-it.sh
+++ b/pep-it.sh
@@ -3,5 +3,5 @@
 set -e
 
 basedir=$(dirname $0)
-pep8 --ignore=E201,E202,E241,E251 --exclude=tests,config,features "$basedir"
+pep8 --ignore=E201,E202,E241,E251 --exclude=tests,config,features,build,src,venv "$basedir"
 pep8 --ignore=E201,E202,E241,E251,E501 "$basedir/tests" "$basedir/features"


### PR DESCRIPTION
The `build`, `venv` and `src` directories are created by various
automated jobs (pip and virtualenv). They should never be included
in PEP8 checks.
