### PR TITLE
Don't proceed if something fails in run_tests

### DIFF
--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 set -o pipefail
 


### PR DESCRIPTION
It's very confusing when a command 4 lines up fails which causes a
strange error later on.

The script should go boom sooner...

![BOOM](http://imgc.allpostersimages.com/images/P-473-488-90/63/6319/HL27100Z/posters/boom-comic-pop-art-art-print-poster.jpg)

_Thanks Ralph for your guidance on making inspirational pull requests..._
