### PR TITLE
Fix EVL failures upload error

### DIFF
--- a/backdrop/contrib/evl_upload_filters.py
+++ b/backdrop/contrib/evl_upload_filters.py
@@ -70,6 +70,27 @@ def service_volumetrics(rows):
            taxDiskApplications, sornApplications]
 
 
+def _to_int(value, value_if_empty=0):
+    """
+    >>> _to_int('56')
+    56
+    >>> _to_int(56)
+    56
+    >>> _to_int('', value_if_empty=20)
+    20
+    >>> _to_int(' ', value_if_empty=20)
+    20
+    """
+
+    if isinstance(value, int):
+        return value
+    elif isinstance(value, basestring):
+        stripped = value.strip()
+        return int(stripped) if len(stripped) else value_if_empty
+    else:
+        return int(value)
+
+
 def service_failures(sheets):
     rows = list(list(sheets)[1])
     timestamp = rows[1][1]
@@ -87,8 +108,8 @@ def service_failures(sheets):
             return
 
         reason_code = int(row[1])
-        tax_disc_failures = int(row[2] or 0)
-        sorn_failures = int(row[4] or 0)
+        tax_disc_failures = _to_int(row[2], value_if_empty=0)
+        sorn_failures = _to_int(row[4], value_if_empty=0)
 
         yield failure("tax-disc", reason_code, tax_disc_failures, description,
                       timestamp)

--- a/tests/contrib/test_evl_upload_filters.py
+++ b/tests/contrib/test_evl_upload_filters.py
@@ -60,6 +60,7 @@ class EVLServiceVolumetrics(unittest.TestCase):
             self.ignore_rows(4) +
             [["No tax-disc failure", 0, '', 0, 2]] +
             [["No sorn failure", 1, 20, 0, '']] +
+            [["Failure with whitespace in value", 1, 20, 0, ' ']] +
             [[None, "None in first column means end of failures list"]]
         ]
 
@@ -71,6 +72,8 @@ class EVLServiceVolumetrics(unittest.TestCase):
             [timestamp, "2013-07-30.sorn.0",     "sorn",     0, 2,  "No tax-disc failure"],
             [timestamp, "2013-07-30.tax-disc.1", "tax-disc", 1, 20, "No sorn failure"],
             [timestamp, "2013-07-30.sorn.1",     "sorn",     1, 0,  "No sorn failure"],
+            [timestamp, "2013-07-30.tax-disc.1", "tax-disc", 1, 20, "Failure with whitespace in value"],
+            [timestamp, "2013-07-30.sorn.1",     "sorn",     1, 0,  "Failure with whitespace in value"],
         ]))
 
     def test_converts_channel_volumetrics_raw_data_to_normalised_data(self):


### PR DESCRIPTION
If a cell is an empty string, it is correctly removed and there's no
attempt to convert it to an integer. Recently we've seen a sneaky
whitespace which isn't treated the same. This causes an upload failure.
- Created a test to reproduce.
- Fixed by calling string.strip() to ignore whitespace in cells.
