### PR TITLE
Upgrade pymongo and rauth

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,10 @@ Flask-FeatureFlags==0.3
 gunicorn==18.0
 invoke
 pip==1.4.1
-pymongo==2.6.1
+pymongo==2.6.3
 python-dateutil==2.1
 pytz==2013b
-rauth==0.5.4
+rauth==0.6.2
 statsd==2.0.3
 xlrd==0.9.2
 -e git+https://github.com/alphagov/python-logstash-formatter.git@fix-docstring#egg=logstash_formatter


### PR DESCRIPTION
Do not upgrade python-dateutil because it is not backwards compatible.
