### PR TITLE
Really reliable replicated replicas

### DIFF
--- a/backdrop/admin/app.py
+++ b/backdrop/admin/app.py
@@ -30,7 +30,7 @@ log_handler.set_up_logging(app, GOVUK_ENV)
 app.url_map.converters["bucket"] = BucketConverter
 
 db = database.Database(
-    app.config['MONGO_HOST'],
+    app.config['MONGO_HOSTS'],
     app.config['MONGO_PORT'],
     app.config['DATABASE_NAME']
 )

--- a/backdrop/admin/config/development.py
+++ b/backdrop/admin/config/development.py
@@ -4,7 +4,7 @@ ALLOW_TEST_SIGNIN=True
 SECRET_KEY = "something unique and secret"
 
 DATABASE_NAME = "backdrop"
-MONGO_HOST = 'localhost'
+MONGO_HOSTS = ['localhost']
 MONGO_PORT = 27017
 
 try:

--- a/backdrop/admin/config/test.py
+++ b/backdrop/admin/config/test.py
@@ -5,7 +5,7 @@ ALLOW_TEST_SIGNIN = True
 SECRET_KEY = "something unique and secret"
 
 DATABASE_NAME = "backdrop_test"
-MONGO_HOST = 'localhost'
+MONGO_HOSTS = ['localhost']
 MONGO_PORT = 27017
 
 from test_environment import *

--- a/backdrop/core/database.py
+++ b/backdrop/core/database.py
@@ -9,9 +9,20 @@ from backdrop.core.nested_merge import nested_merge, InvalidOperationError
 
 class Database(object):
 
-    def __init__(self, host, port, name):
-        self._mongo = pymongo.MongoReplicaSetClient(host, port,
-                                                    replicaSet='production')
+    def __init__(self, hosts, port, name):
+        """
+        Create a list to feed to the MongoReplicaSetClient in a way it understands
+        e.g. MongoReplicaSetClient(
+            [u'hostname_one:27017', u'hostname_two:27017', u'hostname_three:27017'])
+        See http://api.mongodb.org/python/current/examples/high_availability.html#mongoreplicasetclient for more
+        """
+
+        clientList = []
+        for host in hosts:
+            clientList.append('{0}:{1}'.format(host, port))
+
+        self._mongo = pymongo.MongoReplicaSetClient(
+            ','.join(clientList), replicaSet='production')
         self.name = name
 
     def alive(self):

--- a/backdrop/read/api.py
+++ b/backdrop/read/api.py
@@ -27,7 +27,7 @@ app.config.from_object(
     "backdrop.read.config.{}".format(GOVUK_ENV))
 
 db = database.Database(
-    app.config['MONGO_HOST'],
+    app.config['MONGO_HOSTS'],
     app.config['MONGO_PORT'],
     app.config['DATABASE_NAME']
 )

--- a/backdrop/read/config/development.py
+++ b/backdrop/read/config/development.py
@@ -1,5 +1,5 @@
 DATABASE_NAME = "backdrop"
-MONGO_HOST = 'localhost'
+MONGO_HOSTS = ['localhost']
 MONGO_PORT = 27017
 LOG_LEVEL = "DEBUG"
 RAW_QUERIES_ALLOWED = {

--- a/backdrop/read/config/test.py
+++ b/backdrop/read/config/test.py
@@ -1,5 +1,5 @@
 DATABASE_NAME = "backdrop_test"
-MONGO_HOST = 'localhost'
+MONGO_HOSTS = ['localhost']
 MONGO_PORT = 27017
 LOG_LEVEL = "ERROR"
 RAW_QUERIES_ALLOWED = {

--- a/backdrop/write/api.py
+++ b/backdrop/write/api.py
@@ -27,7 +27,7 @@ app.config.from_object(
     "backdrop.write.config.{}".format(GOVUK_ENV))
 
 db = database.Database(
-    app.config['MONGO_HOST'],
+    app.config['MONGO_HOSTS'],
     app.config['MONGO_PORT'],
     app.config['DATABASE_NAME']
 )

--- a/backdrop/write/config/development.py
+++ b/backdrop/write/config/development.py
@@ -1,5 +1,5 @@
 DATABASE_NAME = "backdrop"
-MONGO_HOST = 'localhost'
+MONGO_HOSTS = ['localhost']
 MONGO_PORT = 27017
 LOG_LEVEL = "DEBUG"
 BUCKET_AUTO_ID_KEYS = {

--- a/backdrop/write/config/test.py
+++ b/backdrop/write/config/test.py
@@ -1,5 +1,5 @@
 DATABASE_NAME = "backdrop_test"
-MONGO_HOST = 'localhost'
+MONGO_HOSTS = ['localhost']
 MONGO_PORT = 27017
 LOG_LEVEL = "DEBUG"
 CLIENT_ID = "it's not important here"

--- a/run_migrations.py
+++ b/run_migrations.py
@@ -30,7 +30,8 @@ def load_config(env):
 
 
 def get_database(config):
-    return Database(config.MONGO_HOST, config.MONGO_PORT, config.DATABASE_NAME)
+    return Database(
+        config.MONGO_HOSTS, config.MONGO_PORT, config.DATABASE_NAME)
 
 
 def get_migrations():

--- a/tasks.py
+++ b/tasks.py
@@ -19,7 +19,7 @@ def get_database():
         "backdrop.write.config.%s" % environment()
     )
     return database.Database(
-        app.config['MONGO_HOST'],
+        app.config['MONGO_HOSTS'],
         app.config['MONGO_PORT'],
         app.config['DATABASE_NAME']
     )

--- a/tests/core/integration/test_bucket_integration.py
+++ b/tests/core/integration/test_bucket_integration.py
@@ -13,7 +13,7 @@ from backdrop.core.timeseries import WEEK
 from backdrop.read.query import Query
 from tests.support.test_helpers import d_tz
 
-HOST = 'localhost'
+HOST = ['localhost']
 PORT = 27017
 DB_NAME = 'performance_platform_test'
 BUCKET = 'bucket_integration_test'

--- a/tests/core/integration/test_database_integration.py
+++ b/tests/core/integration/test_database_integration.py
@@ -9,7 +9,7 @@ from backdrop.core.database import Repository, GroupingError, \
 from backdrop.read.query import Query
 from tests.support.test_helpers import d, d_tz
 
-HOST = 'localhost'
+HOST = ['localhost']
 PORT = 27017
 DB_NAME = 'performance_platform_test'
 BUCKET = 'test_repository_integration'
@@ -762,7 +762,7 @@ class TestRepositoryIntegration_Finding(RepositoryIntegrationTest):
 
 class TestDatabase(unittest.TestCase):
     def setUp(self):
-        self.db = Database('localhost', 27017, 'backdrop_test')
+        self.db = Database(HOST, PORT, DB_NAME)
         self.db.mongo_database["my_capped_collection"].drop()
 
     def test_alive(self):

--- a/tests/core/integration/test_repository.py
+++ b/tests/core/integration/test_repository.py
@@ -5,7 +5,7 @@ from backdrop.core.database import Database
 from backdrop.core.repository import BucketConfigRepository, UserConfigRepository
 from backdrop.core.user import UserConfig
 
-HOST = 'localhost'
+HOST = ['localhost']
 PORT = 27017
 DB_NAME = 'performance_platform_test'
 BUCKET = 'buckets'


### PR DESCRIPTION
- Change to accept a list of hosts, rather than a single host
- Generates a clientlist which will zip up a list of `host:port`

Cool.

![](http://24.media.tumblr.com/c1f582346c56ea9fea715f4cdc36e49b/tumblr_mzban8MjJN1qhwlspo1_500.jpg)
