### PR TITLE
Use ``bash -e`` to fail sooner in replicate-db.sh

### DIFF
--- a/tools/replicate-db.sh
+++ b/tools/replicate-db.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 #
 # Replicate backdrop mongo db from a source host to a target host.


### PR DESCRIPTION
Else you get strange effects if an early command fails.
