### PR TITLE
Remove Python 2.6 from build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
-matrix:
-  allow_failures:
-    - python: "2.6"
 # Need mongodb for testing
 services: mongodb
 # command to install dependencies


### PR DESCRIPTION
While it is useful to advertise the versions that backdrop does not work
with I think this can be done in a better way than a travis build that
runs every time but always fails.
