### PR TITLE
Separated out setting the bearer  in behave tests

### DIFF
--- a/features/end_to_end.feature
+++ b/features/end_to_end.feature
@@ -4,6 +4,7 @@ Feature: end-to-end platform test
     Scenario: write data to platform
         Given I have the data in "dinosaurs.json"
           and I have a bucket named "reptiles"
+          and I use the bearer token for the bucket
           and bucket setting raw_queries_allowed is true
          when I post the data to "/reptiles"
          then I should get back a status of "200"
@@ -11,6 +12,7 @@ Feature: end-to-end platform test
     Scenario: write and retrieve data from platform
         Given I have the data in "dinosaurs.json"
           and I have a bucket named "reptiles"
+          and I use the bearer token for the bucket
           and bucket setting raw_queries_allowed is true
          when I post the data to "/reptiles"
           and I go to "/reptiles?filter_by=size:big"
@@ -20,6 +22,7 @@ Feature: end-to-end platform test
     Scenario: writing events and retrieving weekly data
         Given I have the data in "grouped_timestamps.json"
           and I have a bucket named "flavour_events"
+          and I use the bearer token for the bucket
          when I post the data to "/flavour_events"
           and I go to "/flavour_events?period=week&group_by=flavour&start_at=2013-03-18T00:00:00Z&end_at=2013-04-08T00:00:00Z"
          then I should get back a status of "200"

--- a/features/read_api/group_by_day.feature
+++ b/features/read_api/group_by_day.feature
@@ -5,6 +5,7 @@ Feature: querying for data grouped by day
     Scenario: grouping data by day between two timestamps
          Given I have the data in "daily_timestamps.json"
            And I have a bucket named "day"
+           And I use the bearer token for the bucket
           When I post the data to "/day"
           Then I should get back a status of "200"
           When I go to "/day?period=day&start_at=2013-04-04T00:00:00Z&end_at=2013-04-11T00:00:00Z"

--- a/features/read_api/group_by_hour.feature
+++ b/features/read_api/group_by_hour.feature
@@ -5,6 +5,7 @@ Feature: querying for data grouped by hour
     Scenario: grouping data by hour between two days
          Given I have the data in "hourly_timestamps.json"
            And I have a bucket named "hour"
+           And I use the bearer token for the bucket
           When I post the data to "/hour"
           Then I should get back a status of "200"
           When I go to "/hour?period=hour&start_at=2013-04-01T13:00:00Z&end_at=2013-04-03T13:00:00Z"

--- a/features/read_api/monthly_grouping.feature
+++ b/features/read_api/monthly_grouping.feature
@@ -5,6 +5,7 @@ Feature: querying for data grouped by month
     Scenario: grouping data by month between two allowed timestamps
          Given I have the data in "monthly_timestamps.json"
            And I have a bucket named "month"
+           And I use the bearer token for the bucket
           When I post the data to "/month"
           Then I should get back a status of "200"
           When I go to "/month?period=month&start_at=2013-05-01T00:00:00Z&end_at=2013-07-01T00:00:00Z"
@@ -13,6 +14,7 @@ Feature: querying for data grouped by month
     Scenario: grouping data by month between two disallowed timestamps
          Given I have the data in "monthly_timestamps.json"
            And I have a bucket named "month_with_wrong_timestamp"
+           And I use the bearer token for the bucket
           When I post the data to "/month_with_wrong_timestamp"
           Then I should get back a status of "200"
           When I go to "/month_with_wrong_timestamp?period=month&start_at=2013-05-02T00:00:00Z&end_at=2013-07-01T00:00:00Z"

--- a/features/steps/write_api.py
+++ b/features/steps/write_api.py
@@ -15,6 +15,11 @@ def step(context, fixture_name):
         context.data_to_post = fixture.read()
 
 
+@given('I use the bearer token for the bucket')
+def step(context):
+    context.bearer_token = "%s-bearer-token" % context.bucket
+
+
 @when('I post the data to "{bucket_name}"')
 def step(context, bucket_name):
     if not (context and 'bucket' in context):
@@ -23,7 +28,7 @@ def step(context, bucket_name):
         bucket_name,
         data=context.data_to_post,
         content_type="application/json",
-        headers=[('Authorization', "Bearer %s-bearer-token" % context.bucket)],
+        headers=_make_headers_from_context(context),
     )
 
 
@@ -33,7 +38,7 @@ def step(context, path):
         path,
         data=context.data_to_post,
         content_type="application/json",
-        headers=[('Authorization', "Bearer %s-bearer-token" % context.bucket)],
+        headers=_make_headers_from_context(context),
     )
 
 
@@ -43,7 +48,7 @@ def step(context, filename, bucket_name):
     context.response = context.client.post(
         "/" + bucket_name + "/upload",
         files={"file": open("tmp/%s" % filename, "r")},
-        headers=[('Authorization', "Bearer %s-bearer-token" % context.bucket)],
+        headers=_make_headers_from_context(context),
     )
 
 
@@ -58,3 +63,9 @@ def step(context, amount, key, time):
     time_query = parser.parse(time)
     result = context.client.storage()[context.bucket].find({key: time_query})
     assert_that(list(result), has_length(int(amount)))
+
+
+def _make_headers_from_context(context):
+    if context and 'bearer_token' in context:
+        return [('Authorization', "Bearer %s" % context.bearer_token)]
+    return []

--- a/features/write_api/licensing.feature
+++ b/features/write_api/licensing.feature
@@ -4,5 +4,6 @@ Feature: licensing -> performance platform integration
     Scenario: receiving data from licensing
         Given I have the data in "SubmittedApplicationsReport.json"
           and I have a bucket named "licensing"
+          and I use the bearer token for the bucket
          when I post the data to "/licensing"
          then I should get back a status of "200"

--- a/features/write_api/write_api.feature
+++ b/features/write_api/write_api.feature
@@ -18,6 +18,7 @@ Feature: the performance platform write api
     Scenario: posting one object to a bucket
         Given I have the data in "dinosaur.json"
           and I have a bucket named "my_dinosaur_bucket"
+          and I use the bearer token for the bucket
          when I post the data to "/my_dinosaur_bucket"
          then I should get back a status of "200"
          and  the stored data should contain "1" "name" equaling "t-rex"
@@ -25,6 +26,7 @@ Feature: the performance platform write api
     Scenario: posting a list of objects to a bucket
         Given I have the data in "dinosaurs.json"
           and I have a bucket named "my_dinosaur_bucket"
+          and I use the bearer token for the bucket
          when I post the data to "/my_dinosaur_bucket"
          then I should get back a status of "200"
          and  the stored data should contain "2" "size" equaling "big"
@@ -33,6 +35,7 @@ Feature: the performance platform write api
     Scenario: tagging data with week start at
         Given I have the data in "timestamps.json"
           and I have a bucket named "data_with_times"
+          and I use the bearer token for the bucket
          when I post the data to "/data_with_times"
          then I should get back a status of "200"
           and the stored data should contain "3" "_week_start_at" on "2013-03-11"
@@ -41,6 +44,7 @@ Feature: the performance platform write api
     Scenario: posting to a bucket with data group and data type
         Given I have the data in "timestamps.json"
           and I have a bucket named "data_with_times"
+          and I use the bearer token for the bucket
           and bucket setting data_group is "transaction"
           and bucket setting data_type is "timings"
          when I post to the specific path "/data/transaction/timings"


### PR DESCRIPTION
Previously, when you used any of the behavious like "when I post to
/govuk_visitors" it would automatically set a valid bearer token. That
makes it difficult to test the access control functionality, as well as
the new "create collection" endpoint, which uses some _different_ token
(not related to a collection)

I've made it so you can explicitly specify that the token should be set
based on the bucket you've already referenced. This paves the way for
setting alternative tokens (or none at all).
