### PR TITLE
Update max age expected migration

### DIFF
--- a/migrations/006_add_last_time_expected.py
+++ b/migrations/006_add_last_time_expected.py
@@ -33,40 +33,59 @@ log = logging.getLogger(__name__)
 def up(db):
     all_buckets = db.get_collection('buckets').find()
     for bucket in all_buckets:
-        if bucket.get('max_age_expected') is not None:
-            continue
         max_age_expected = calculate_max_age(bucket)
-        bucket['max_age_expected'] = max_age_expected
-        log.info("Adding max age of: %s to %s bucket" %
-                 (max_age_expected, bucket['name']))
-        db.get_collection('buckets').save(bucket)
+        if max_age_expected != bucket['max_age_expected']:
+            bucket['max_age_expected'] = max_age_expected
+            log.info("Adding max age of: %s to %s bucket" %
+                     (max_age_expected, bucket['name']))
+            db.get_collection('buckets').save(bucket)
 
 
 def calculate_max_age(bucket):
-    dt = bucket['data_type']
+    max_ages_for_field = {
+        'name': {
+            # These buckets are dead
+            'evl_channel_volumetrics': None,
+            'evl_services_volumetrics': None,
+            'gcloud_proportion_sme': None,
+            'government_annotations': None,
+            'land_registry_search_volumetrics': None,
+            'hmrc_preview': None,
+            'deposit_foreign_marriage_monitoring': None,
+            'deposit_foreign_marriage_realtime': None,
+            'deposit_foreign_marriage_journey': None,
+            'twilio_prototype': None,
+        },
+        'data_group': {
+            # Housing is not receiving any more data
+            'housing-policy': None,
+            # Student finance is not receiving data yet
+            'student-finance': None,
+        },
+        'data_type': {
+            # 5mins for realtime
+            'realtime': minutes(5),
+            # Journey and customer satisfaction sets should update daily
+            'journey': hours(25),
+            'customer-satisfaction': hours(25),
+            # Jobs run every hour, we're giving 2hrs as tolerance
+            'monitoring': hours(2),
+            # GCloud sales data is expected monthly
+            'sales': months(1.25),
+        }
+    }
+    for field in ['name', 'data_group', 'data_type']:
+        try:
+            max_ages = max_ages_for_field[field]
+            return max_ages[bucket[field]]
+        except KeyError:
+            pass
+    # Default to 1 month expectation
+    return months(1)
 
-    dead_bucket_names = [
-        'evl_channel_volumetrics',
-        'government_annotations',
-        'land_registry_search_volumetrics',
-        'hmrc_preview',
-        'housing_policy_annual_mortgage_lending',
-        'housing_policy_monthly_mortgage_lending'
-    ]
 
-    if bucket['name'] in dead_bucket_names:
-        return None
-
-    return {
-        # 5mins for realtime
-        'realtime': minutes(5),
-        # Journey and customer satisfaction sets should update daily
-        'journey': hours(25),
-        'customer-satisfaction': hours(25),
-        # Jobs run every hour, we're giving 2hrs as tolerance
-        'monitoring': hours(2),
-        'sales': months(1.25),
-    }.get(dt, months(1))  # default to a month
+def calculate_max_age_for(bucket, field, params):
+    return params[bucket[field]]
 
 
 def months(months):


### PR DESCRIPTION
This is not a good way of doing this. This is no longer a migration,
it's a scripted way of keeping the metadata up to date. This will be
better when it's managed by stagecraft.
- Recalculate max_age_expected for every bucket, only update the bucket
  if this has changed.
- Set all housing and student-finance data groups to None
- Set a couple of extra specific buckets to None
- Change how the max age is calculate, first try by bucket name, then by
  data group, then by data type, then default to 1 month.
