### PR TITLE
Remove _updated_at from bucket model

### DIFF
--- a/migrations/009_fix_and_resize_capped_collections.py
+++ b/migrations/009_fix_and_resize_capped_collections.py
@@ -56,7 +56,6 @@ def set_bucket_metadata_capped(mongo_db, collection_name):
             "$set": {
                 "capped_size": CAP_SIZE,
                 "realtime": True,
-                "_updated_at":  timeutils.now()
             }
         },
         upsert=False,
@@ -70,7 +69,6 @@ def set_bucket_metadata_uncapped(mongo_db, collection_name):
             "$set": {
                 "capped_size": None,
                 "realtime": False,
-                "_updated_at": timeutils.now()
             }
         },
         upsert=False,


### PR DESCRIPTION
This was not there before and it being there causes the model to break.
There is a question over whether it should be there.
