### PR TITLE
Update STAGECRAFT_URL in development

### DIFF
--- a/backdrop/read/config/development.py
+++ b/backdrop/read/config/development.py
@@ -45,5 +45,5 @@ RAW_QUERIES_ALLOWED = {
     "lpa_journey": True,
 }
 
-STAGECRAFT_URL = 'http://localhost:8080'
+STAGECRAFT_URL = 'http://localhost:3204'
 STAGECRAFT_DATA_SET_QUERY_TOKEN = 'stagecraft-data-set-query-token-fake'


### PR DESCRIPTION
It seems this was missed, it was causing the below stack trace when
I tried to push data into a bucket.

```
  File "/var/apps/backdrop/backdrop/core/cache_control.py", line 19, in new_func
    resp = make_response(func(*args, **kwargs))
  File "/var/apps/backdrop/backdrop/write/api.py", line 86, in post_to_bucket
    bucket_config = bucket_repository.retrieve(name=bucket_name)
  File "/var/apps/backdrop/backdrop/core/repository.py", line 74, in retrieve
    json_response = _get_json_url(data_set_url, self._stagecraft_token)
  File "/var/apps/backdrop/backdrop/core/repository.py", line 123, in _get_json_url
    auth_header]))
  File "/home/vagrant/.virtualenvs/backdrop-write-3039/local/lib/python2.7/site-packages/requests/api.py", line 55, in get
    return request('get', url, **kwargs)
  File "/home/vagrant/.virtualenvs/backdrop-write-3039/local/lib/python2.7/site-packages/requests/api.py", line 44, in request
    return session.request(method=method, url=url, **kwargs)
  File "/home/vagrant/.virtualenvs/backdrop-write-3039/local/lib/python2.7/site-packages/requests/sessions.py", line 335, in request
    resp = self.send(prep, **send_kwargs)
  File "/home/vagrant/.virtualenvs/backdrop-write-3039/local/lib/python2.7/site-packages/requests/sessions.py", line 438, in send
    r = adapter.send(request, **kwargs)
  File "/home/vagrant/.virtualenvs/backdrop-write-3039/local/lib/python2.7/site-packages/requests/adapters.py", line 327, in send
    raise ConnectionError(e)
ConnectionError: HTTPConnectionPool(host='localhost', port=8080): Max retries exceeded with url: /data-sets/gov_uk_content_top_count (Caused by <class 'socket.error'>: [Errno 111] Connection refused)
```
