### PR TITLE
Fix Stagecraft port: 3204, not 8080

### DIFF
--- a/backdrop/admin/config/development.py
+++ b/backdrop/admin/config/development.py
@@ -12,5 +12,5 @@ try:
 except ImportError:
     from development_environment_sample import *
 
-STAGECRAFT_URL = 'http://localhost:8080'
+STAGECRAFT_URL = 'http://localhost:3204'
 STAGECRAFT_DATA_SET_QUERY_TOKEN = 'stagecraft-data-set-query-token-fake'

--- a/backdrop/read/config/development.py
+++ b/backdrop/read/config/development.py
@@ -45,5 +45,5 @@ RAW_QUERIES_ALLOWED = {
     "lpa_journey": True,
 }
 
-STAGECRAFT_URL = 'http://localhost:8080'
+STAGECRAFT_URL = 'http://localhost:3204'
 STAGECRAFT_DATA_SET_QUERY_TOKEN = 'stagecraft-data-set-query-token-fake'

--- a/backdrop/write/config/development.py
+++ b/backdrop/write/config/development.py
@@ -13,5 +13,5 @@ try:
 except ImportError:
     from development_environment_sample import *
 
-STAGECRAFT_URL = 'http://localhost:8080'
+STAGECRAFT_URL = 'http://localhost:3204'
 STAGECRAFT_DATA_SET_QUERY_TOKEN = 'stagecraft-data-set-query-token-fake'

--- a/features/steps/read_api.py
+++ b/features/steps/read_api.py
@@ -10,6 +10,7 @@ import pytz
 from features.support.stagecraft import StagecraftService
 
 FIXTURE_PATH = os.path.join(os.path.dirname(__file__), '..', 'fixtures')
+TEST_STAGECRAFT_PORT = 3204
 
 
 @given('the api is running in protected mode')
@@ -45,7 +46,8 @@ def ensure_bucket_exists(context, bucket_name, settings={}):
 
     if 'mock_stagecraft_server' in context and context.mock_stagecraft_server:
         context.mock_stagecraft_server.stop()
-    context.mock_stagecraft_server = StagecraftService(8080, url_response_dict)
+    context.mock_stagecraft_server = StagecraftService(
+        TEST_STAGECRAFT_PORT, url_response_dict)
     context.mock_stagecraft_server.start()
 
     context.bucket = bucket_name
@@ -121,7 +123,8 @@ def step(context, bucket_name):
 def step(context):
     if 'mock_stagecraft_server' in context and context.mock_stagecraft_server:
         context.mock_stagecraft_server.stop()
-    context.mock_stagecraft_server = StagecraftService(8080, {})
+    context.mock_stagecraft_server = StagecraftService(
+        TEST_STAGECRAFT_PORT, {})
     context.mock_stagecraft_server.start()
 
 


### PR DESCRIPTION
We changed the Stagecraft port but obviously haven't tested in development,
as Backdrop was still pointing to the old port.

Cheers @pwaller for this one.
