### PR TITLE
Use /dev/urandom, not /dev/random

### DIFF
--- a/tools/generate-token.sh
+++ b/tools/generate-token.sh
@@ -4,4 +4,4 @@
 # Generate a random token 
 #
 
-head -c 500 /dev/random | shasum -a 512
+head -c 500 /dev/urandom | shasum -a 512


### PR DESCRIPTION
Because /dev/random blocks which is super irritating (tokens take >30 seconds
to generate on my machine)

Read this: http://www.2uo.de/myths-about-urandom/

If anyone can authoratitively disagree, please feel free to comment and close
this PR :)
