### PR TITLE
Generate shorter tokens

### DIFF
--- a/tools/generate-token.sh
+++ b/tools/generate-token.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 #
-# Generate a random token 
+# Generate a random token
 #
 
-head -c 500 /dev/urandom | shasum -a 512
+# LC_CTYPE=C is specified for OS X, as otherwise tr will return
+# an illegal byte sequence from assuming /dev/urandom is UTF-8
+
+cat /dev/urandom | LC_CTYPE=C tr -cd 'a-zA-Z0-9' | head -c 64
+
+echo '' # Add a newline


### PR DESCRIPTION
I enjoyed the conversation in #262 so much that I decided to make our tokens less secure.

I don't really want to make big assertions about cryptography, but this has reduced the key space from 10^154 to 10^114, so I think we're probably still ok.

I also didn't want to be _the guy who took it all the way down to 20 characters_, so I've gone for 64 to start with.
