### PR TITLE
Remove ambiguous characters from tokens

### DIFF
--- a/tools/generate-token.sh
+++ b/tools/generate-token.sh
@@ -7,6 +7,6 @@
 # LC_CTYPE=C is specified for OS X, as otherwise tr will return
 # an illegal byte sequence from assuming /dev/urandom is UTF-8
 
-cat /dev/urandom | LC_CTYPE=C tr -cd 'a-zA-Z0-9' | head -c 64
+cat /dev/urandom | LC_CTYPE=C tr -cd 'a-z0-9' | tr -d '01oil' | head -c 64
 
 echo '' # Add a newline


### PR DESCRIPTION
These are handled by humans, and occasionally humans use typefaces that do not distinguish between certain characters very well.

This is the reason that I and Q are excluded from UK vehicle registration plates.

Remove the characters zero, one, oh, eye and ell from tokens. Make them all lowercase, because there's no good reason not to.
