### PR TITLE
Better check for upload_filters

### DIFF
--- a/backdrop/core/data_set.py
+++ b/backdrop/core/data_set.py
@@ -90,7 +90,7 @@ class DataSetConfig(_DataSetConfig):
         if not data_set_is_valid(name):
             raise ValueError("DataSet name is not valid: '{}'".format(name))
 
-        if upload_filters is None:
+        if not upload_filters:
             upload_filters = [
                 "backdrop.core.upload.filters.first_sheet_filter"]
 


### PR DESCRIPTION
- Stagecraft may pass this value through as `""` or `[]` or `None` and `if not upload_filters` works for all these cases.
