### PR TITLE
DevVM now lives in pp-puppet

### DIFF
--- a/tools/replicate-db.sh
+++ b/tools/replicate-db.sh
@@ -61,8 +61,8 @@ ssh $SOURCE_HOST "rm -Rf ${FILENAME} ${DUMPDIR}"
 tar xzvf $FILENAME
 
 if [ -z "$2" ]; then
-    pushd ../../pp-development/
-    vagrant ssh -c "cd /var/apps/backdrop/tools && mongorestore --drop ${DUMPDIR}"
+    pushd ../../pp-puppet/
+    vagrant ssh development-1 -c "cd /var/apps/backdrop/tools && mongorestore --drop ${DUMPDIR}"
     popd
 else
     mongorestore --drop -h $DESTINATION_HOST $DUMPDIR


### PR DESCRIPTION
We've moved the dev vm and this replicate script was still referencing
the old location. It now needs to explicitly say development-1 as there
are multiple VMs attached to that Vagrantfile.
