### PR TITLE
Return the correct HTTP status

### DIFF
--- a/features/write_api/write_api.feature
+++ b/features/write_api/write_api.feature
@@ -65,13 +65,15 @@ Feature: the performance platform write api
     Scenario: denying create collection with missing bearer token
         Given I have JSON data '{"capped_size": 0}'
          when I POST to the specific path "/data-sets/new-dataset"
-         then I should get back a status of "403"
+         then I should get back a status of "401"
+          and I should get a "WWW-Authenticate" header of "bearer"
 
     Scenario: denying create collection with incorrect bearer token
         Given I have JSON data '{"capped_size": 0}'
           and I have the bearer token "invalid-bearer-token"
          when I POST to the specific path "/data-sets/new-dataset"
-         then I should get back a status of "403"
+         then I should get back a status of "401"
+          and I should get a "WWW-Authenticate" header of "bearer"
 
     Scenario: creating an uncapped collection
         Given I have JSON data '{"capped_size": 0}'

--- a/tests/support/test_helpers.py
+++ b/tests/support/test_helpers.py
@@ -26,7 +26,7 @@ def is_bad_request():
 
 
 def is_unauthorized():
-    return has_status(403)
+    return has_status(401) and has_header('WWW-Authenticate', 'bearer')
 
 
 def is_not_found():


### PR DESCRIPTION
We should return 401 Unauthorized rather than 403 Forbidden.

Fixes #70590126.
