### PR TITLE
[#69911218] Check auth headers are correctly formed

### DIFF
--- a/backdrop/write/api.py
+++ b/backdrop/write/api.py
@@ -238,7 +238,7 @@ def _validate_auth(data_set_config):
     try:
         auth_header = request.headers['Authorization']
     except KeyError:
-        abort(401, 'Authorization header missing.')
+        abort(401, 'Expected header of form: Authorization: Bearer <token>')
 
     if not auth_header_is_valid(data_set_config, auth_header):
         token = extract_bearer_token(auth_header)

--- a/features/steps/write_api.py
+++ b/features/steps/write_api.py
@@ -48,15 +48,15 @@ def step(context, http_method, path):
 def step(context, http_method, path):
     assert http_method in ('POST', 'PUT'), "Only support POST, PUT"
     http_function = {
-	'POST': context.client.post,
-	'PUT': context.client.put
+        'POST': context.client.post,
+        'PUT': context.client.put
     }[http_method]
 
     context.response = http_function(
-	path,
-	data=context.data_to_post,
-	content_type="application/json",
-	headers=_make_malformed_header_from_context(context),
+        path,
+        data=context.data_to_post,
+        content_type="application/json",
+        headers=_make_malformed_header_from_context(context),
     )
 
 
@@ -129,5 +129,5 @@ def _make_headers_from_context(context):
 
 def _make_malformed_header_from_context(context):
     if context and 'bearer_token' in context:
-	return [('Orthoriszation', "Bearer %s" % context.bearer_token)]
+        return [('Orthoriszation', "Bearer %s" % context.bearer_token)]
     return []

--- a/features/write_api/write_api.feature
+++ b/features/write_api/write_api.feature
@@ -78,16 +78,16 @@ Feature: the performance platform write api
 
     @posting_things
     Scenario: unauthorized when posting with a badly formed authorization header
-	Given I have JSON data '[]'
-	  and I have a data_set named "some_data_set" with settings
-	    | key        | value   |
-	    | data_group | "group" |
-	    | data_type  | "type"  |
-	  and I use the bearer token for the data_set
-	 when I POST to "/data/group/type" with a malformed authorization header
-	 then I should get back a status of "401"
-	  and I should get a "WWW-Authenticate" header of "bearer"
-	  and I should get back the message "Expected header of form: Authorization: Bearer <token>"
+        Given I have JSON data '[]'
+          and I have a data_set named "some_data_set" with settings
+            | key        | value   |
+            | data_group | "group" |
+            | data_type  | "type"  |
+          and I use the bearer token for the data_set
+         when I POST to "/data/group/type" with a malformed authorization header
+         then I should get back a status of "401"
+          and I should get a "WWW-Authenticate" header of "bearer"
+          and I should get back the message "Expected header of form: Authorization: Bearer <token>"
 
     Scenario: denying create collection with missing bearer token
         Given I have JSON data '{"capped_size": 0}'


### PR DESCRIPTION
- Modifies the error message on write api
- Conforms to a feature test and which expects the message `Expected header of form: Authorization: Bearer <token>` for cases where the 'authorization' key can't be found or is malformed
