### PR TITLE
Add a prefix to the statsd key

### DIFF
--- a/backdrop/__init__.py
+++ b/backdrop/__init__.py
@@ -22,4 +22,5 @@ class StatsClient(object):
             return getattr(self._statsd, item)
 
 statsd = StatsClient(
-    _statsd.StatsClient(prefix=os.getenv("GOVUK_STATSD_PREFIX")))
+    _statsd.StatsClient(prefix=os.getenv(
+        "GOVUK_STATSD_PREFIX", "pp.apps.backdrop")))


### PR DESCRIPTION
We have loads of stats at the top leve of our statsd stats in graphite.
It makes looking for things that aren't created by backdrop really
hard.
