### PR TITLE
Fix hostname check in replicate script

### DIFF
--- a/tools/replicate-db.sh
+++ b/tools/replicate-db.sh
@@ -6,8 +6,8 @@
 # one.
 #
 
-if [ "$(hostname)" == "vm" ]; then
-    echo "This script should be run on the host machine!"
+if [ "$(hostname)" == "development-1" ]; then
+    echo "This script should be run on the host machine, not your virtual machine!"
     exit 1
 fi
 
@@ -54,7 +54,7 @@ ssh $SOURCE_HOST "tar czvf ${FILENAME} ${DUMPDIR}"
 # scp tar
 scp $SOURCE_HOST:~/$FILENAME .
 
-# cleanup preview machine
+# clean up remote machine
 ssh $SOURCE_HOST "rm -Rf ${FILENAME} ${DUMPDIR}"
 
 # mongorestore


### PR DESCRIPTION
The hostname of the machine changed when it moved into the pp-puppet repo from pp-development. It's now called `development-1` rather than `vm`.
