### PR TITLE
Exclude tagged branches from travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,6 @@ after_script:
 branches:
   except:
     - release
+    - /^release_[0-9]+$/
 notifications:
   email: false


### PR DESCRIPTION
Tagged branches are created by successful builds in our CI environment. It is
wasteful and potentially clogs up our build pipeline in travis for pull
requests if we also build those versions in travis.
