### PR TITLE
Passing test for signed in user

### DIFF
--- a/features/admin/signin.feature
+++ b/features/admin/signin.feature
@@ -5,7 +5,7 @@ Feature: Sign in
     Given I am logged in as "Max" with email "test@example.com"
     When I go to "/"
     Then I should get a "cache-control" header of "private, must-revalidate"
-    And I should see the text "Signed in as Max"
+    And I should see the signed in user "Max"
 
   Scenario: Show signed in list of actions
     Given I am logged in as "Alex" with email "test@example.com"

--- a/features/steps/splinter.py
+++ b/features/steps/splinter.py
@@ -24,6 +24,13 @@ def step(context, message):
     assert context.client.browser.is_text_present(message)
 
 
+@then(u'I should see the signed in user "{name}"')
+def step(context, name):
+    signed_in_text = context.client.browser.evaluate_script(
+        'document.querySelector("p.navbar-text").innerText;')
+    assert signed_in_text == "Signed in as {}".format(name)
+
+
 @then(u'the "{data_set_name}" data_set should contain in any order')
 def step(context, data_set_name):
     data_set_contains(context, data_set_name, contains_inanyorder)


### PR DESCRIPTION
The behave tests fail locally with the new version on phantomjs (1.9.7), this fixes it.

Tried directly finding the element and using webdrivers text method first but this has the same incorrect idea about the dom. Not found anything obvious about this issue in phantom 1.9.7 and don't want to spend too long so using this hack for now. These tests may become defunct soon anyway.
