### PR TITLE
Allow unknown fields in DataSetConfig

### DIFF
--- a/backdrop/core/data_set.py
+++ b/backdrop/core/data_set.py
@@ -135,7 +135,7 @@ class DataSetConfig(_DataSetConfig):
                 bearer_token=None, upload_format="csv", upload_filters=None,
                 auto_ids=None, queryable=True, realtime=False,
                 capped_size=5040, max_age_expected=2678400,
-                published=True):
+                published=True, **kwargs):
         if not data_set_is_valid(name):
             raise ValueError("DataSet name is not valid: '{}'".format(name))
 

--- a/tests/core/test_data_set.py
+++ b/tests/core/test_data_set.py
@@ -280,6 +280,9 @@ class TestDataSetConfig(object):
         data_set_config = DataSetConfig("name", data_group="group", data_type="type", raw_queries_allowed=True)
         assert_that(data_set_config.raw_queries_allowed, is_(True))
 
+    def test_unknown_fields_do_not_cause_data_set_config_to_fail(self):
+        DataSetConfig('name', data_group='group', data_type='type', unknown=True)
+
     def test_default_values(self):
         data_set = DataSetConfig("default", data_group="with_defaults", data_type="def_type")
 


### PR DESCRIPTION
Before this change, adding a field to the data set config in stagecraft
before backdrop would cause backdrop to fail.
