### PR TITLE
Always return a 200 for delete operations

### DIFF
--- a/backdrop/write/api.py
+++ b/backdrop/write/api.py
@@ -214,10 +214,8 @@ def delete_collection_by_data_set_name(data_set_name):
             )
         )
 
-    if not storage.data_set_exists(data_set_name):
-        abort(404, 'No collection exists with name "{}"'.format(data_set_name))
-
-    storage.delete_data_set(data_set_name)
+    if storage.data_set_exists(data_set_name):
+        storage.delete_data_set(data_set_name)
 
     return jsonify(status='ok', message='Deleted {}'.format(data_set_name))
 

--- a/features/write_api/delete_data_set.feature
+++ b/features/write_api/delete_data_set.feature
@@ -15,8 +15,7 @@ Feature: delete_data_set
           and the collection called "some-dataset" should not exist
 
     @delete_things
-    Scenario: cannot delete a data-set that does not exist
+    Scenario: can delete a data-set that does not exist
         Given I have the bearer token "dev-create-endpoint-token"
          when I send a DELETE request to "/data-sets/some-dataset"
-         then I should get back a status of "404"
-          and I should get back the message "No collection exists with name "some-dataset""
+         then I should get back a status of "200"


### PR DESCRIPTION
This is to allow stagecraft to delete datasets that dont exist in
backdrop. As deletes are idempotent, and deleting a non existent
resource will not change the state of the underlying system it seems
appropriate to do this.
