### PR TITLE
Add test for empty data in PeriodGroupedData

### DIFF
--- a/backdrop/core/response.py
+++ b/backdrop/core/response.py
@@ -152,6 +152,9 @@ class PeriodGroupedData(object):
     def amount_to_shift(self, delta):
         is_reversed = delta < 0
 
+        if len(self._data) == 0:
+            return 0
+
         return min([
             first_nonempty(i['values'], is_reversed) for i in self._data],
             key=abs)

--- a/tests/read/test_weekly_grouped_data.py
+++ b/tests/read/test_weekly_grouped_data.py
@@ -86,3 +86,7 @@ class TestWeeklyGroupedData(unittest.TestCase):
             has_entry("_start_at", d_tz(2013, 4, 8)),
             has_entry("_start_at", d_tz(2013, 4, 15))
         ))
+
+    def test_with_empty_data(self):
+        data = PeriodGroupedData([], WEEK)
+        assert_that(data.amount_to_shift(7), equal_to(0))


### PR DESCRIPTION
If an empty data array is passed to a query with a duration parameter,
currently we get a Python exception. This fixes that error.
