### PR TITLE
Set a 5min cache on the `_status/data-sets` endpoint

### DIFF
--- a/backdrop/read/api.py
+++ b/backdrop/read/api.py
@@ -98,7 +98,7 @@ def health_check():
 
 
 @app.route('/_status/data-sets', methods=['GET'])
-@cache_control.nocache
+@cache_control.set('max-age=300')
 @statsd.timer('read.route.heath_check.data_set')
 def data_set_health():
 


### PR DESCRIPTION
- Bringing back 60+ objects every time we hit this, so should be cached
- 5mins feels like a reasonable amount
