### PR TITLE
Revert "Set a 5min cache on the `_status/data-sets` endpoint"

### DIFF
--- a/backdrop/read/api.py
+++ b/backdrop/read/api.py
@@ -98,7 +98,7 @@ def health_check():
 
 
 @app.route('/_status/data-sets', methods=['GET'])
-@cache_control.set('max-age=300')
+@cache_control.nocache
 @statsd.timer('read.route.heath_check.data_set')
 def data_set_health():
 


### PR DESCRIPTION
Reverts alphagov/backdrop#333

Healthchecks shouldn't really be cached as they are meant to report the status of the app at that time. This was done in part to address intermittent 503s we were seeing from this endpoint due to the volume of data sets it has to query. This issue is going to get worse until a point where it only returns 503s, so this bandaid is not particularly useful.
