### PR TITLE
Create a data set if it doesn't exist when writing

### DIFF
--- a/backdrop/core/data_set.py
+++ b/backdrop/core/data_set.py
@@ -69,6 +69,10 @@ class DataSet(object):
             now - last_updated - max_age_delta
         ).total_seconds())
 
+    def create_if_not_exists(self):
+        if not self.storage.data_set_exists(self.name):
+            self.storage.create_data_set(self.name, self.config['capped_size'])
+
     def empty(self):
         return self.storage.empty_data_set(self.name)
 

--- a/backdrop/write/api.py
+++ b/backdrop/write/api.py
@@ -260,6 +260,7 @@ def _validate_auth(data_set_config):
 
 def _append_to_data_set(data_set_config, data, ok_message=None):
     data_set = DataSet(storage, data_set_config)
+    data_set.create_if_not_exists()
     data_set.store(data)
 
     if ok_message:
@@ -270,6 +271,7 @@ def _append_to_data_set(data_set_config, data, ok_message=None):
 
 def _empty_data_set(data_set_config):
     data_set = DataSet(storage, data_set_config)
+    data_set.create_if_not_exists()
     data_set.empty()
     return jsonify(
         status='ok',

--- a/features/write_api/empty_data_set.feature
+++ b/features/write_api/empty_data_set.feature
@@ -5,9 +5,10 @@ Feature: empty_data_set
     Scenario: emptying a data-set by PUTing an empty JSON list
         Given I have the data in "dinosaur.json"
           and I have a data_set named "some_data_set" with settings
-            | key        | value         |
-            | data_group | "group"       |
-            | data_type  | "type"        |
+            | key         | value         |
+            | data_group  | "group"       |
+            | data_type   | "type"        |
+            | capped_size | 0             |
           and I use the bearer token for the data_set
          when I POST to the specific path "/data/group/type"
         given I have JSON data '[]'
@@ -20,9 +21,10 @@ Feature: empty_data_set
     @empty_data_set
     Scenario: PUT is only implemented for an empty JSON list
         Given I have a data_set named "some_data_set" with settings
-            | key        | value         |
-            | data_group | "group"       |
-            | data_type  | "type"        |
+            | key         | value         |
+            | data_group  | "group"       |
+            | data_type   | "type"        |
+            | capped_size | 0             |
           and I use the bearer token for the data_set
         given I have JSON data '[{"a": 1}]'
          when I PUT to the specific path "/data/group/type"

--- a/tests/support/performanceplatform_client.py
+++ b/tests/support/performanceplatform_client.py
@@ -42,6 +42,7 @@ def fake_data_set_exists(name, data_group="group", data_type="type",
                 'name': setup_data_set_name,
                 'data_group': data_group,
                 'data_type': data_type,
+                'capped_size': 0,
             }
             config = dict(base_config.items() + data_set_kwargs.items())
             with pretend_this_data_set_exists(config):


### PR DESCRIPTION
This decouples creation of a data set in stagecraft from creation in
backdrop, which has been the cause of a lot of the bugs around creating
data sets.

Once this is done stagecraft can be updated to remove it's dependency on
backdrop. Once that is done the create and delete end points here can be
removed.

One point to note is that collections will not be removed when the data
set is deleted in stagecraft. The data set will not be available
(queryable or writable), however, if a data set with the same group and
type is created the previous data will still be there. Although it can
be emptied.
