### PR TITLE
Do not record 4xx class as error

### DIFF
--- a/backdrop/read/api.py
+++ b/backdrop/read/api.py
@@ -80,7 +80,6 @@ def uncaught_error_handler(e):
 @app.errorhandler(404)
 @app.errorhandler(405)
 def http_error_handler(e):
-    app.logger.exception(e)
     return (jsonify(status='error',
                     message=getattr(e, 'name', 'Internal error')),
             getattr(e, 'code', 500))

--- a/backdrop/write/api.py
+++ b/backdrop/write/api.py
@@ -79,8 +79,6 @@ def uncaught_error_handler(e):
 @app.errorhandler(404)
 @app.errorhandler(405)
 def http_error_handler(e):
-    _record_write_error(e)
-
     if e.code == 401:
         description = getattr(e, 'description',
                               'Bad or missing Authorization header')


### PR DESCRIPTION
User errors should not be logged as application errors. Doing so masks
real errors.
