### PR TITLE
Attach logging to root handler

### DIFF
--- a/backdrop/core/log_handler.py
+++ b/backdrop/core/log_handler.py
@@ -22,13 +22,14 @@ def get_json_log_handler(path, app_name):
 
 def set_up_logging(app, env):
     log_level = logging._levelNames[app.config['LOG_LEVEL']]
-    app.logger.addHandler(
+    logger = logging.getLogger()
+    logger.addHandler(
         get_log_file_handler("log/%s.log" % env, log_level)
     )
-    app.logger.addHandler(
+    logger.addHandler(
         get_json_log_handler("log/%s.log.json" % env, app.name)
     )
-    app.logger.setLevel(log_level)
+    logger.setLevel(log_level)
     app.logger.info("{} logging started".format(app.name))
     app.before_request(create_request_logger(app))
     app.after_request(create_response_logger(app))


### PR DESCRIPTION
This means that we will capture log messages that are not specifically
written to flasks logger.

Before this commit we're not capturing any error logs from the rest of
our application or from dependencies (unless they cause exceptions that
bubble up to the flask layer).
