### PR TITLE
Allow origin * on read api errors

### DIFF
--- a/backdrop/read/api.py
+++ b/backdrop/read/api.py
@@ -62,6 +62,7 @@ app.json_encoder = JsonEncoder
 
 
 @app.errorhandler(500)
+@crossdomain(origin='*')
 def uncaught_error_handler(e):
     """
     This shouldn't happen. If we get here an unspecified uncaught exception
@@ -79,6 +80,7 @@ def uncaught_error_handler(e):
 
 @app.errorhandler(404)
 @app.errorhandler(405)
+@crossdomain(origin='*')
 def http_error_handler(e):
     return (jsonify(status='error',
                     message=getattr(e, 'name', 'Internal error')),


### PR DESCRIPTION
Set Access-Control-Allow-Origin header to \* when the read API errors.
This is to allow easier debugging in spotlight.

This was originally going to be done in Nginx, however, on investigation
it was discovered that we'd need a non-standard module to add headers to
the response. This was a simpler route.
