### PR TITLE
HTTP validation is different to staleness

### DIFF
--- a/backdrop/core/cache_control.py
+++ b/backdrop/core/cache_control.py
@@ -1,8 +1,7 @@
 """
 Cache control decorators for flask apps
 """
-import hashlib
-from flask import make_response, request
+from flask import make_response
 from functools import wraps
 
 
@@ -21,14 +20,3 @@ def set(cache_control):
             return resp
         return new_func
     return decorator
-
-
-def etag(func):
-    @wraps(func)
-    def new_func(*args, **kwargs):
-        resp = make_response(func(*args, **kwargs))
-        resp.set_etag(hashlib.sha1(resp.data).hexdigest())
-        resp.make_conditional(request)
-        return resp
-
-    return new_func

--- a/backdrop/core/http_validation.py
+++ b/backdrop/core/http_validation.py
@@ -1,0 +1,18 @@
+"""
+HTTP Validation decorators for flask apps
+See http://tools.ietf.org/html/rfc7234#section-4.3
+"""
+import hashlib
+from flask import make_response, request
+from functools import wraps
+
+
+def etag(func):
+    @wraps(func)
+    def new_func(*args, **kwargs):
+        resp = make_response(func(*args, **kwargs))
+        resp.set_etag(hashlib.sha1(resp.data).hexdigest())
+        resp.make_conditional(request)
+        return resp
+
+    return new_func

--- a/backdrop/read/api.py
+++ b/backdrop/read/api.py
@@ -8,7 +8,7 @@ from flask_featureflags import FeatureFlag
 
 from .query import parse_query_from_request
 from .validation import validate_request_args
-from ..core import log_handler, cache_control
+from ..core import log_handler, cache_control, http_validation
 from ..core.data_set import DataSet
 from ..core.errors import InvalidOperationError
 from ..core.timeutils import as_utc
@@ -157,7 +157,7 @@ def data(data_group, data_type):
 
 
 @app.route('/<data_set_name>', methods=['GET', 'OPTIONS'])
-@cache_control.etag
+@http_validation.etag
 def query(data_set_name):
     with statsd.timer('read.route.{data_set_name}'.format(
             data_set_name=data_set_name)):


### PR DESCRIPTION
Validation and freshness are distinct concerns for HTTP caches, as
defined in RFC7234. Separate out the decorators for Cache-Control and
ETag.
