### PR TITLE
Fix integer auto id error

### DIFF
--- a/backdrop/core/records.py
+++ b/backdrop/core/records.py
@@ -55,7 +55,7 @@ def _generate_auto_id(record, auto_id_keys):
                 ', '.join(missing_keys)))
 
     return b64encode('.'.join(
-        record[key] for key in auto_id_keys))
+        str(record[key]) for key in auto_id_keys))
 
 
 def parse_timestamp(record):

--- a/tests/core/test_records.py
+++ b/tests/core/test_records.py
@@ -10,7 +10,7 @@ class TestRecords(TestCase):
         assert_that(_generate_auto_id({'foo': 'foo'}, ['foo']), is_('Zm9v'))
 
     def test__generate_auto_id_generates_auto_ids_correctly_for_integers(self):
-        assert_that(_generate_auto_id({'foo': 1}, ['foo']), is_('Zm9v'))
+        assert_that(_generate_auto_id({'foo': 1, 'bar': 'foo'}, ['foo', 'bar']), is_('MS5mb28='))
 
     def test__generate_auto_id_throws_error_when_key_not_matched(self):
         assert_raises(


### PR DESCRIPTION
This was causing a 500 on legal-aid-handling-time-volumes due to an int field being part of the auto id.

I'll test this on preview once merged.
