### PR TITLE
Don’t build housekeeping branches in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,6 @@ branches:
   except:
     - release
     - /^release_[0-9]+$/
+    - /^deployed-to-(preview|staging|production)$/
 notifications:
   email: false


### PR DESCRIPTION
Minor change to try to be a good travis citizen and avoid unnecessary
builds.

The deployed-to-{env} branches are used by us internally to compare what
we’re about to deploy. Those versions of the code will have already been
built in travis when we merged the pull request from a topic branch.
