### PR TITLE
Add more headers to Access-Control-Allow-Headers

### DIFF
--- a/backdrop/read/api.py
+++ b/backdrop/read/api.py
@@ -47,7 +47,7 @@ admin_api = client.AdminAPI(
     app.config['STAGECRAFT_URL'],
     app.config['SIGNON_API_USER_TOKEN'],
     dry_run=False,
-    request_id_fn = generate_request_id,
+    request_id_fn=generate_request_id,
 )
 
 DEFAULT_DATA_SET_QUERYABLE = True
@@ -208,7 +208,9 @@ def fetch(data_set_config):
         # if the client uses custom headers
         response = app.make_default_options_response()
         response.headers['Access-Control-Max-Age'] = '86400'
-        response.headers['Access-Control-Allow-Headers'] = 'cache-control'
+        response.headers[
+            'Access-Control-Allow-Headers'] = \
+            'cache-control, govuk-request-id, request-id'
     else:
         raw_queries_allowed = data_set_config.get(
             'raw_queries_allowed', DEFAULT_DATA_SET_RAW_QUERIES)

--- a/tests/read/test_read_api_query_endpoint.py
+++ b/tests/read/test_read_api_query_endpoint.py
@@ -118,4 +118,4 @@ class PreflightChecksApiTestCase(unittest.TestCase):
     def test_cors_requests_can_cache_control(self):
         response = self.app.open('/data_set', method='OPTIONS')
         assert_that(response.headers['Access-Control-Allow-Headers'],
-                    is_('cache-control'))
+                    is_('cache-control, govuk-request-id, request-id'))

--- a/tests/read/test_read_api_service_data_endpoint.py
+++ b/tests/read/test_read_api_service_data_endpoint.py
@@ -12,11 +12,13 @@ from tests.support.test_helpers import has_status, has_header, d_tz
 
 
 class NoneData(object):
+
     def data(self):
         return None
 
 
 class QueryingApiTestCase(unittest.TestCase):
+
     def setUp(self):
         self.app = api.app.test_client()
 
@@ -110,42 +112,50 @@ class QueryingApiTestCase(unittest.TestCase):
 
 
 class PreflightChecksApiTestCase(unittest.TestCase):
+
     def setUp(self):
         self.app = api.app.test_client()
         api.storage._mongo.drop_database(api.app.config['DATABASE_NAME'])
 
     @fake_data_set_exists("data_set", data_group="some-group", data_type="some-type")
     def test_cors_preflight_requests_have_empty_body(self):
-        response = self.app.open('/data/some-group/some-type', method='OPTIONS')
+        response = self.app.open(
+            '/data/some-group/some-type', method='OPTIONS')
         assert_that(response.status_code, is_(200))
         assert_that(response.data, is_(""))
 
     @fake_data_set_exists("data_set", data_group="some-group", data_type="some-type")
     def test_cors_preflight_are_allowed_from_all_origins(self):
-        response = self.app.open('/data/some-group/some-type', method='OPTIONS')
+        response = self.app.open(
+            '/data/some-group/some-type', method='OPTIONS')
         assert_that(response, has_header('Access-Control-Allow-Origin', '*'))
 
     @fake_data_set_exists("data_set", data_group="some-group", data_type="some-type")
     def test_cors_preflight_result_cache(self):
-        response = self.app.open('/data/some-group/some-type', method='OPTIONS')
+        response = self.app.open(
+            '/data/some-group/some-type', method='OPTIONS')
         assert_that(response, has_header('Access-Control-Max-Age', '86400'))
 
     @fake_data_set_exists("data_set", data_group="some-group", data_type="some-type")
     def test_cors_requests_can_cache_control(self):
-        response = self.app.open('/data/some-group/some-type', method='OPTIONS')
-        assert_that(response, has_header('Access-Control-Allow-Headers', 'cache-control'))
+        response = self.app.open(
+            '/data/some-group/some-type', method='OPTIONS')
+        assert_that(response, has_header('Access-Control-Allow-Headers',
+                                         'cache-control, govuk-request-id, request-id'))
 
     @fake_data_set_exists("data_set", data_group="some-group", data_type="some-type", raw_queries_allowed=True)
     def test_max_age_is_30_min_for_non_realtime_data_sets(self):
         response = self.app.get('/data/some-group/some-type')
 
-        assert_that(response, has_header('Cache-Control', 'max-age=1800, must-revalidate'))
+        assert_that(
+            response, has_header('Cache-Control', 'max-age=1800, must-revalidate'))
 
     @fake_data_set_exists("data_set", data_group="some-group", data_type="some-type", realtime=True, raw_queries_allowed=True)
     def test_max_age_is_2_min_for_realtime_data_sets(self):
         response = self.app.get('/data/some-group/some-type')
 
-        assert_that(response, has_header('Cache-Control', 'max-age=120, must-revalidate'))
+        assert_that(
+            response, has_header('Cache-Control', 'max-age=120, must-revalidate'))
 
     @fake_data_set_exists("data_set", data_group="some-group", data_type="some-type", raw_queries_allowed=True, published=False)
     def test_cache_control_is_set_to_no_cache_for_unpublished_data_sets(self):

--- a/tests/read/test_validators.py
+++ b/tests/read/test_validators.py
@@ -2,10 +2,11 @@ import unittest
 from hamcrest import *
 from backdrop.read.validation import ParameterMustBeOneOfTheseValidator, MondayValidator, FirstOfMonthValidator, ParamDependencyValidator
 
-#TODO: looked around and couldn't see any other validator tests
+# TODO: looked around and couldn't see any other validator tests
 
 
 class TestValidators(unittest.TestCase):
+
     def test_value_must_be_one_of_these_validator(self):
         request = {
             "foo": "not_allowed"


### PR DESCRIPTION
We recently added functionality to proxy request headers to backend
services.

See https://github.com/alphagov/spotlight/pull/813

This code also runs in the browser, so we need to ensure that it isn’t
restricted by browser security. The other option would be not to try to
set those headers in the client.
