### PR TITLE
Pass client_id through to user.json

### DIFF
--- a/backdrop/admin/signonotron2.py
+++ b/backdrop/admin/signonotron2.py
@@ -17,6 +17,7 @@ class Signonotron2(object):
             access_token_url="%s/oauth/token" % base_url,
             base_url=base_url
         )
+        self.client_id = client_id
         self.redirect_url = redirect_url
 
     def __json_access_token(self, something):
@@ -52,7 +53,8 @@ class Signonotron2(object):
             return None, None
 
         session = self.signon.get_session(access_token)
-        user_details_response = session.get('user.json')
+        user_details_response = session.get(
+            'user.json?client_id={0}'.format(self.client_id))
         if user_details_response.status_code in [200, 201]:
             _user_details = user_details_response.json()
             user_details = _user_details, \

--- a/tests/admin/test_signonotron2.py
+++ b/tests/admin/test_signonotron2.py
@@ -107,3 +107,19 @@ class Signonotron2TestCase(unittest.TestCase):
         assert_that(access_token, is_(None))
         assert_that(mock_logger.warn.call_args[0][0],
                     starts_with('Could not parse token from response'))
+
+    def test_user_details_submits_client_id(self):
+        oauth_service = Signonotron2("clientid", None, None, "")
+        oauth_service.signon = Mock()
+        session_object = Mock()
+        response = Response()
+        user_details_json = \
+            { "user": {"name": "Gareth The Wizard", "permissions": "signin"}}
+        response._content = json.dumps(user_details_json)
+        response.status_code = 200
+        session_object.get.return_value = response
+        oauth_service.signon.get_session.return_value = session_object
+
+        oauth_service.user_details("token is accepted")
+
+        session_object.get.assert_called_with('user.json?client_id=clientid')


### PR DESCRIPTION
Signonotron2 requires you to pass the client_id through to the user.json
endpoint so that you can't use any apps token to gain access.
