### PR TITLE
Add performance testing dir to .ackrc

### DIFF
--- a/.ackrc
+++ b/.ackrc
@@ -2,6 +2,7 @@
 --ignore-dir=tmp
 --ignore-dir=log
 --ignore-dir=build
+--ignore-dir=tests/fixtures/perf/
 --ignore-file=match:.coverage
 --ignore-file=match:nosetests.xml
 


### PR DESCRIPTION
This file has hundreds of thousands of lines and is not useful to be included when using ack.
