### PR TITLE
Quieten pip in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 services: mongodb
 # command to install dependencies
 install: 
-  - pip install -r requirements_for_tests.txt --use-mirrors
+  - pip install -q -r requirements_for_tests.txt --use-mirrors
 # command to run tests
 env:
   - SKIP_VIRUS_SCAN=1 SKIP_SPLINTER_TESTS=1 MONGO_REPLICA_SET='' NO_AUTOPEP8=1


### PR DESCRIPTION
I think we could do without 100s of lines of compilation warnings (from modules we don't own) in each build log.
