### PR TITLE
Use write API config for celery tasks

### DIFF
--- a/backdrop/transformers/tasks.py
+++ b/backdrop/transformers/tasks.py
@@ -1,4 +1,17 @@
-from worker import app
+from celery import Celery
+
+# Load the appropriate config from backdrop.write
+import importlib
+from os import getenv
+
+GOVUK_ENV = getenv("GOVUK_ENV", "development")
+config = importlib.import_module(
+    "backdrop.write.config.{}".format(GOVUK_ENV))
+
+app = Celery(
+    'transformations',
+    broker=config.TRANSFORMER_AMQP_URL,
+    include=['backdrop.transformers.tasks'])
 
 
 @app.task(ignore_result=True)

--- a/backdrop/write/config/development.py
+++ b/backdrop/write/config/development.py
@@ -17,3 +17,5 @@ STAGECRAFT_URL = 'http://localhost:3204'
 STAGECRAFT_DATA_SET_QUERY_TOKEN = 'dev-data-set-query-token'
 
 SIGNON_API_USER_TOKEN = 'development-oauth-access-token'
+
+TRANSFORMER_AMQP_URL = 'amqp://transformer:notarealpw@localhost:5672/%2Ftransformations'

--- a/backdrop/write/config/test.py
+++ b/backdrop/write/config/test.py
@@ -9,6 +9,7 @@ DATA_SET_AUTO_ID_KEYS = {
     "data_set_with_timestamp_auto_id": ["_timestamp", "key"],
     "evl_volumetrics": ["_timestamp", "service", "transaction"],
 }
+TRANSFORMER_AMQP_URL = 'memory://'
 
 from development import (STAGECRAFT_COLLECTION_ENDPOINT_TOKEN, STAGECRAFT_URL,
                          STAGECRAFT_DATA_SET_QUERY_TOKEN, SIGNON_API_USER_TOKEN)


### PR DESCRIPTION
Since the worker is likely to be separated competely in future, instantiate a separate celery instance for tasks to use.

This also means transformer and backdrop.write deploys are completely independent of each other.
