### PR TITLE
Use transformer config for tasks

### DIFF
--- a/backdrop/transformers/tasks.py
+++ b/backdrop/transformers/tasks.py
@@ -1,12 +1,12 @@
 from celery import Celery
 
-# Load the appropriate config from backdrop.write
+# Load the appropriate config as a python module
 import importlib
 from os import getenv
 
 GOVUK_ENV = getenv("GOVUK_ENV", "development")
 config = importlib.import_module(
-    "backdrop.write.config.{}".format(GOVUK_ENV))
+    "backdrop.transformers.config.{}".format(GOVUK_ENV))
 
 app = Celery(
     'transformations',


### PR DESCRIPTION
Although there's an implicit dependency on backdrop.write's config (it and the transformer must be configured to use the same AMQP URL), it's too fragile to depend on config deployed by a different fabric task.

We specify config both in tasks and the worker so that they can be more easily split in future.
