### PR TITLE
Add task for calculating user satisfaction

### DIFF
--- a/backdrop/transformers/tasks/user_satisfaction.py
+++ b/backdrop/transformers/tasks/user_satisfaction.py
@@ -1,0 +1,28 @@
+def calculate_rating(datum):
+    # See
+    # https://github.com/alphagov/spotlight/blob/ca291ffcc86a5397003be340ec263a2466b72cfe/app/common/collections/user-satisfaction.js
+    if not datum['total:sum']:
+        return None
+    # Copy datum before we mutate it.
+    datum = dict(datum)
+    min_score = 1
+    max_score = 5
+    score = 0
+    for rating in range(min_score, max_score + 1):
+        rating_key = 'rating_{0}:sum'.format(rating)
+        score += datum[rating_key] * rating
+        # Set rating key that spotlight expects.
+        datum['rating_{0}'.format(rating)] = datum[rating_key]
+    mean = score / (datum['total:sum'])
+    return (mean - min_score) / (max_score - min_score)
+
+
+def compute(data):
+    # Calculate rating and set keys that spotlight expects.
+    computed = []
+    for datum in data:
+        datum['number_of_responses'] = datum['total:sum']
+        datum['days_with_responses'] = datum['_count']
+        datum['rating'] = calculate_rating(datum)
+        computed.append(datum)
+    return computed

--- a/tests/transformers/tasks/test_user_satisfaction.py
+++ b/tests/transformers/tasks/test_user_satisfaction.py
@@ -1,0 +1,76 @@
+import unittest
+
+from hamcrest import assert_that, is_
+
+from backdrop.transformers.tasks.user_satisfaction import compute
+
+
+data = [
+    {
+        "_count": 7.0,
+        "_start_at": "2014-11-10T00:00:00+00:00",
+        "_end_at": "2014-11-17T00:00:00+00:00",
+        "rating_1:sum": 1.0,
+        "rating_2:sum": 1.0,
+        "rating_3:sum": 1.0,
+        "rating_4:sum": 1.0,
+        "rating_5:sum": 1.0,
+        "total:sum": 5.0
+    },
+    {
+        "_count": 7.0,
+        "_start_at": "2014-11-17T00:00:00+00:00",
+        "_end_at": "2014-11-24T00:00:00+00:00",
+        "rating_1:sum": 1.0,
+        "rating_2:sum": 1.0,
+        "rating_3:sum": 1.0,
+        "rating_4:sum": 1.0,
+        "rating_5:sum": 6.0,
+        "total:sum": 10.0
+    },
+    {
+        "_count": 7.0,
+        "_start_at": "2014-11-24T00:00:00+00:00",
+        "_end_at": "2014-12-01T00:00:00+00:00",
+        "rating_1:sum": 6.0,
+        "rating_2:sum": 1.0,
+        "rating_3:sum": 1.0,
+        "rating_4:sum": 1.0,
+        "rating_5:sum": 1.0,
+        "total:sum": 10.0
+    },
+    {
+        "_count": 0.0,
+        "_start_at": "2014-12-01T00:00:00+00:00",
+        "_end_at": "2014-12-08T00:00:00+00:00",
+        "rating_1:sum": None,
+        "rating_2:sum": None,
+        "rating_3:sum": None,
+        "rating_4:sum": None,
+        "rating_5:sum": None,
+        "total:sum": None
+    },
+    {
+        "_count": 7.0,
+        "_start_at": "2014-12-01T00:00:00+00:00",
+        "_end_at": "2014-12-08T00:00:00+00:00",
+        "rating_1:sum": 0.0,
+        "rating_2:sum": 0.0,
+        "rating_3:sum": 0.0,
+        "rating_4:sum": 0.0,
+        "rating_5:sum": 0.0,
+        "total:sum": 0.0
+    }
+]
+
+
+class UserSatisfactionTestCase(unittest.TestCase):
+    def test_compute_user_satisfaction(self):
+        transformed_data = compute(data)
+
+        assert_that(len(transformed_data), is_(5))
+        assert_that(transformed_data[0]['rating'], is_(0.5))
+        assert_that(transformed_data[1]['rating'], is_(0.75))
+        assert_that(transformed_data[2]['rating'], is_(0.25))
+        assert_that(transformed_data[3]['rating'], is_(None))
+        assert_that(transformed_data[4]['rating'], is_(None))


### PR DESCRIPTION
This calculates user satisfaction based on weekly grouped data. It also sets the keys spotlight expects in the response data.

If a week contains no ratings, or the entire weekly response is null, the user satisfaction rating is also null.
