### PR TITLE
Required fields for transforms (_id, _timestamp)

### DIFF
--- a/backdrop/transformers/tasks/rate.py
+++ b/backdrop/transformers/tasks/rate.py
@@ -3,6 +3,8 @@ import functools
 
 from collections import OrderedDict
 
+from .util import encode_id
+
 
 def group_by(keys, arr):
     groupped = OrderedDict()
@@ -54,6 +56,8 @@ def compute_for_date(matchingAttribute, valueAttribute, denominatorRe, numerator
         rate = numerator / denominator if denominator > 0 else None
 
     return {
+        '_id': encode_id(start_at, end_at),
+        '_timestamp': start_at,
         '_start_at': start_at,
         '_end_at': end_at,
         'rate': rate,

--- a/backdrop/transformers/tasks/user_satisfaction.py
+++ b/backdrop/transformers/tasks/user_satisfaction.py
@@ -1,3 +1,6 @@
+from .util import encode_id
+
+
 def calculate_rating(datum):
     # See
     # https://github.com/alphagov/spotlight/blob/ca291ffcc86a5397003be340ec263a2466b72cfe/app/common/collections/user-satisfaction.js
@@ -21,6 +24,8 @@ def compute(data):
     # Calculate rating and set keys that spotlight expects.
     computed = []
     for datum in data:
+        datum['_id'] = encode_id(datum['_start_at'], datum['_end_at'])
+        datum['_timestamp'] = datum['_start_at']
         datum['number_of_responses'] = datum['total:sum']
         datum['days_with_responses'] = datum['_count']
         datum['rating'] = calculate_rating(datum)

--- a/backdrop/transformers/tasks/util.py
+++ b/backdrop/transformers/tasks/util.py
@@ -1,0 +1,7 @@
+import base64
+
+
+def encode_id(*parts):
+    joined = '_'.join(parts)
+    joined_bytes = joined.encode('utf-8')
+    return base64.urlsafe_b64encode(joined_bytes)

--- a/tests/transformers/tasks/test_rate.py
+++ b/tests/transformers/tasks/test_rate.py
@@ -54,5 +54,17 @@ class ComputeTestCase(unittest.TestCase):
         })
 
         assert_that(len(transformed_data), is_(2))
+        assert_that(
+            transformed_data[0]['_id'],
+            is_('MjAxMy0xMS0yNVQwMDowMDowMCswMDowMF8yMDEzLTEyLTAyVDAwOjAwOjAwKzAwOjAw'))
+        assert_that(
+            transformed_data[0]['_timestamp'],
+            is_('2013-11-25T00:00:00+00:00'))
+        assert_that(
+            transformed_data[0]['_start_at'],
+            is_('2013-11-25T00:00:00+00:00'))
+        assert_that(
+            transformed_data[0]['_end_at'],
+            is_('2013-12-02T00:00:00+00:00'))
         assert_that(transformed_data[0]['rate'], is_(2.0 / 3.0))
         assert_that(transformed_data[1]['rate'], is_(None))

--- a/tests/transformers/tasks/test_user_satisfaction.py
+++ b/tests/transformers/tasks/test_user_satisfaction.py
@@ -69,6 +69,18 @@ class UserSatisfactionTestCase(unittest.TestCase):
         transformed_data = compute(data)
 
         assert_that(len(transformed_data), is_(5))
+        assert_that(
+            transformed_data[0]['_id'],
+            is_('MjAxNC0xMS0xMFQwMDowMDowMCswMDowMF8yMDE0LTExLTE3VDAwOjAwOjAwKzAwOjAw'))
+        assert_that(
+            transformed_data[0]['_timestamp'],
+            is_('2014-11-10T00:00:00+00:00'))
+        assert_that(
+            transformed_data[0]['_start_at'],
+            is_('2014-11-10T00:00:00+00:00'))
+        assert_that(
+            transformed_data[0]['_end_at'],
+            is_('2014-11-17T00:00:00+00:00'))
         assert_that(transformed_data[0]['rating'], is_(0.5))
         assert_that(transformed_data[1]['rating'], is_(0.75))
         assert_that(transformed_data[2]['rating'], is_(0.25))

--- a/tests/transformers/tasks/test_util.py
+++ b/tests/transformers/tasks/test_util.py
@@ -1,0 +1,13 @@
+import unittest
+
+from hamcrest import assert_that, is_
+
+from backdrop.transformers.tasks.util import encode_id
+
+
+class UtilTestCase(unittest.TestCase):
+    def test_encode_id(self):
+        assert_that(
+            encode_id('foo', 'bar'),
+            is_('Zm9vX2Jhcg==')
+        )


### PR DESCRIPTION
Backdrop requires that incoming data points should have a _timestamp and
an _id will be generated if there isn't one. Given that we want to the
transforms to be idempotent and the transforms know about the data that
is going to be submitted I have moved _id generation into them.

_timestamp is set to the start of the period in both cases, which
reflects how the front end considers the _start_at field (as a synonym
for _timestamp)
