### PR TITLE
Don't dispatch task if there is no data

### DIFF
--- a/tests/write/test_api.py
+++ b/tests/write/test_api.py
@@ -2,8 +2,9 @@ import datetime
 import unittest
 
 from hamcrest import assert_that, is_
+from mock import patch
 
-from backdrop.write.api import bounding_dates
+from backdrop.write.api import bounding_dates, trigger_transforms
 
 
 class BoundingDatesTestCase(unittest.TestCase):
@@ -20,3 +21,41 @@ class BoundingDatesTestCase(unittest.TestCase):
 
         assert_that(earliest.day, is_(1))
         assert_that(latest.day, is_(9))
+
+
+class TriggerTransformsTestCase(unittest.TestCase):
+
+    @patch('backdrop.write.api.celery_app')
+    def test_trigger_transforms(self, mock_celery_app):
+        earliest = datetime.datetime(2014, 9, 3)
+        latest = datetime.datetime(2014, 9, 10)
+        data = [
+            {'_timestamp': earliest},
+            {'_timestamp': latest},
+        ]
+
+        trigger_transforms({'name': 'dataset'}, data)
+
+        mock_celery_app.send_task.assert_called_with(
+            'backdrop.transformers.dispatch.entrypoint',
+            args=('dataset', earliest, latest))
+
+    @patch('backdrop.write.api.celery_app')
+    def test_trigger_transforms_no_data(self, mock_celery_app):
+        trigger_transforms({'name': 'dataset'}, [])
+        assert_that(mock_celery_app.send_task.called, is_(False))
+
+    @patch('backdrop.write.api.celery_app')
+    def test_trigger_transforms_with_dates(self, mock_celery_app):
+        earliest = datetime.datetime(2014, 9, 3)
+        latest = datetime.datetime(2014, 9, 10)
+
+        trigger_transforms(
+            {'name': 'dataset'},
+            earliest=earliest,
+            latest=latest
+        )
+
+        mock_celery_app.send_task.assert_called_with(
+            'backdrop.transformers.dispatch.entrypoint',
+            args=('dataset', earliest, latest))


### PR DESCRIPTION
I've pulled out the triggering of tasks to a separate function, this
then handles avoiding dispatch if there is no data.

I have also removed dispatching of tasks from PUT as this is only used
for cleaning out a data set and the transformed data set should be
emptied separately.
