### PR TITLE
Add tests for transforms endpoint

### DIFF
--- a/tests/write/test_api.py
+++ b/tests/write/test_api.py
@@ -1,11 +1,16 @@
 import datetime
+import json
 import unittest
 import pytz
 
 from hamcrest import assert_that, is_
 from mock import patch
 
+from backdrop.write import api
 from backdrop.write.api import bounding_dates, trigger_transforms, parse_bounding_dates
+
+from tests.support.performanceplatform_client import fake_data_set_exists, fake_no_data_sets_exist
+from tests.support.test_helpers import is_ok
 
 
 class BoundingDatesTestCase(unittest.TestCase):
@@ -78,3 +83,49 @@ class TriggerTransformsTestCase(unittest.TestCase):
         mock_celery_app.send_task.assert_called_with(
             'backdrop.transformers.dispatch.entrypoint',
             args=('dataset', earliest, latest))
+
+
+class TriggerTransformsEndpointTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.app = api.app.test_client()
+
+    @fake_data_set_exists("foo", data_group="some-group", data_type="some-type", bearer_token="foo-bearer-token")
+    def test_endpoint_succeeds(self):
+
+        data = json.dumps({
+            "_start_at": "2014-12-17T00:00:00Z",
+        })
+
+        response = self.app.post(
+            '/data/some-group/some-type/transform',
+            data=data,
+            content_type='application/json',
+            headers=[('Authorization', 'Bearer foo-bearer-token')],
+        )
+        assert_that(response, is_ok())
+
+    @fake_data_set_exists("foo", data_group="some-group", data_type="some-type", bearer_token="foo-bearer-token")
+    @patch('backdrop.write.api.trigger_transforms')
+    def test_endpoint_triggers_task(self, mock_trigger_transforms):
+
+        earliest = datetime.datetime(2014, 12, 17, 0, 0)
+        latest = datetime.datetime(2014, 12, 18, 0, 0)
+        data = json.dumps({
+            "_start_at": str(earliest),
+            "_end_at": str(latest),
+        })
+
+        self.app.post(
+            '/data/some-group/some-type/transform',
+            data=data,
+            content_type='application/json',
+            headers=[('Authorization', 'Bearer foo-bearer-token')],
+        )
+        mock_trigger_transforms.assert_called_with({'bearer_token': 'foo-bearer-token',
+                                                    'capped_size': 0,
+                                                    'name': 'foo',
+                                                    'data_type': 'some-type',
+                                                    'data_group': 'some-group'},
+                                                   earliest=earliest,
+                                                   latest=latest)


### PR DESCRIPTION
We need to ensure a task is created when the transforms endpoint is called with a valid request.
