### PR TITLE
Create output dataset if missing using the api.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ gunicorn==19.1.1
 invoke
 isodate==0.5.0
 jsonschema==2.4
-performanceplatform-client==0.3.0
+performanceplatform-client==0.4.0
 pip==1.5.6
 pymongo==2.7.2
 python-dateutil==2.2


### PR DESCRIPTION
Default params are those of the parent. If it's realtime for instance
the transform target probably also needs to be realtime. The only
difference is the data_type and consequently the name (as this is auto
generated)

Relies on:

https://github.com/alphagov/performanceplatform-client.py/pull/43