### PR TITLE
Add filter_by_prefix parameter for regex support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ number of scores.
 
 `GET /data/$DATA_GROUP/$DATA_TYPE?filter_by=name:Foo` returns all elements with `name` equal to "Foo".
 
+`GET /data/$DATA_GROUP/$DATA_TYPE?filter_by_prefix=name:Foo` returns all elements with `name` beginning with "Foo".
+
 Other parameters:
 
 - `start_at` (YYYY-MM-DDTHH:MM:SS+HH:MM) and `end_at` (YYYY-MM-DDTHH:MM:SS+HH:MM)

--- a/backdrop/core/query.py
+++ b/backdrop/core/query.py
@@ -11,7 +11,8 @@ This is the internal Query object
 _Query = namedtuple(
     '_Query',
     ['start_at', 'end_at', 'delta', 'period',
-     'filter_by', 'group_by', 'sort_by', 'limit', 'collect', 'flatten', 'inclusive'])
+     'filter_by', 'filter_by_prefix', 'group_by', 'sort_by', 'limit',
+     'collect', 'flatten', 'inclusive'])
 
 
 class Query(_Query):
@@ -19,8 +20,9 @@ class Query(_Query):
     @classmethod
     def create(cls,
                start_at=None, end_at=None, duration=None, delta=None,
-               period=None, filter_by=None, group_by=None,
-               sort_by=None, limit=None, collect=None, flatten=None, inclusive=None):
+               period=None, filter_by=None, filter_by_prefix=None,
+               group_by=None, sort_by=None, limit=None, collect=None,
+               flatten=None, inclusive=None):
         delta = None
         if duration is not None:
             date = start_at or end_at or now()
@@ -28,7 +30,8 @@ class Query(_Query):
             start_at, end_at = cls.__calculate_start_and_end(period, date,
                                                              delta)
         return Query(start_at, end_at, delta, period, filter_by or [],
-                     group_by or [], sort_by, limit, collect or [], flatten, inclusive)
+                     filter_by_prefix or [], group_by or [], sort_by, limit,
+                     collect or [], flatten, inclusive)
 
     @staticmethod
     def __calculate_start_and_end(period, date, delta):

--- a/backdrop/core/storage/mongo.py
+++ b/backdrop/core/storage/mongo.py
@@ -186,13 +186,20 @@ def get_mongo_spec(query):
     {}
     >>> get_mongo_spec(Query.create(filter_by=[('foo', 'bar')]))
     {'foo': 'bar'}
+    >>> get_mongo_spec(Query.create(filter_by_prefix=[('foo', 'bar')]))
+    {'foo': 'bar'}
     >>> get_mongo_spec(Query.create(start_at=dt(2012, 12, 12)))
     {'_timestamp': {'$gte': datetime.datetime(2012, 12, 12, 0, 0)}}
     """
     time_range = time_range_to_mongo_query(
         query.start_at, query.end_at, query.inclusive)
 
-    return dict(query.filter_by + time_range.items())
+    if query.filter_by:
+        filter_term = query.filter_by
+    else:
+        filter_term = query.filter_by_prefix
+
+    return dict(filter_term + time_range.items())
 
 
 def time_range_to_mongo_query(start_at, end_at, inclusive=False):

--- a/backdrop/read/validation.py
+++ b/backdrop/read/validation.py
@@ -48,6 +48,7 @@ class ParameterValidator(Validator):
             'duration',
             'period',
             'filter_by',
+            'filter_by_prefix',
             'group_by',
             'sort_by',
             'limit',
@@ -118,9 +119,17 @@ class BooleanValidator(Validator):
 class FilterByValidator(Validator):
 
     def validate(self, request_args, context):
+
+        if 'filter_by' in request_args and 'filter_by_prefix' in request_args:
+            self.add_error("Cannot use both filter_by "
+                           "and filter_by_prefix in the same query")
         MultiValueValidator(
             request_args,
             param_name='filter_by',
+            validate_field_value=self.validate_field_value)
+        MultiValueValidator(
+            request_args,
+            param_name='filter_by_prefix',
             validate_field_value=self.validate_field_value)
 
     def validate_field_value(self, value, request_args, context):

--- a/features/read_api/collect.feature
+++ b/features/read_api/collect.feature
@@ -38,6 +38,13 @@ Feature: collect fields into grouped responses
          and the "1st" result should have "value:sum" with json "27"
          and the "1st" result should have "value:mean" with json "6.75"
 
+    Scenario: should be able to perform maths on collect with filter_by_prefix
+        Given "sort_and_limit.json" is in "foo" data_set
+         when I go to "/foo?group_by=type&filter_by_prefix=type:wild&collect=value:sum&collect=value:mean"
+         then I should get back a status of "200"
+         and the "1st" result should have "value:sum" with json "27"
+         and the "1st" result should have "value:mean" with json "6.75"
+
     Scenario: should be able to perform maths on collect when flattened
         Given "sort_and_limit.json" is in "foo" data_set
          when I go to "/foo?group_by=type&filter_by=type:wild&collect=value:sum&collect=value:mean&flatten=true"

--- a/features/read_api/combination_query.feature
+++ b/features/read_api/combination_query.feature
@@ -16,6 +16,15 @@ Feature: more complex combination of parameters that are used by clients
           and the "1st" result should have "values" with item with entries "{"_start_at":"2013-01-28T00:00:00+00:00","_end_at":"2013-02-04T00:00:00+00:00","_count":2}"
           and the "1st" result should have "values" with item with entries "{"_start_at":"2013-02-04T00:00:00+00:00","_end_at":"2013-02-11T00:00:00+00:00","_count":5}"
 
+    Scenario: for an authority get weekly data for the top 3 licences between two points in time using prefix filter
+         when I go to "/licensing?group_by=licenceUrlSlug&filter_by_prefix=authorityUrlSlug:testp&start_at=2013-01-28T00:00:00%2B00:00&end_at=2013-03-29T00:00:00%2B00:00&period=week&collect=authorityName&collect=licenceName&sort_by=_count:descending&limit=3"
+         then I should get back a status of "200"
+          and the JSON should have "3" results
+          and the "1st" result should have "licenceUrlSlug" equaling "fake-licence-3"
+          and the "1st" result should have "values" with item with entries "{"_start_at":"2013-01-28T00:00:00+00:00","_end_at":"2013-02-04T00:00:00+00:00","_count":2}"
+          and the "1st" result should have "values" with item with entries "{"_start_at":"2013-02-04T00:00:00+00:00","_end_at":"2013-02-11T00:00:00+00:00","_count":5}"
+
+
     Scenario: for an authority get weekly data between two points in time
          when I go to "/licensing?filter_by=authorityUrlSlug:testport&start_at=2013-02-04T00:00:00%2B00:00&end_at=2013-03-29T00:00:00%2B00:00&period=week"
          then I should get back a status of "200"

--- a/features/read_api/filter.feature
+++ b/features/read_api/filter.feature
@@ -60,6 +60,44 @@ Feature: filtering queries for read api
          then I should get back a status of "200"
           and the JSON should have "3" results
 
+    Scenario: filtering by a key and prefix value
+        Given "licensing.json" is in "foo" data_set with settings
+            | key                 | value |
+            | raw_queries_allowed | true  |
+         when I go to "/foo?filter_by_prefix=authority:Camd"
+         then I should get back a status of "200"
+          and the JSON should have "2" results
+
+    Scenario: prefix filtering by a field name starting with "$" is not allowed because of security reasons
+        Given "licensing.json" is in "weekly" data_set
+         when I go to "/weekly?filter_by_prefix=$prefix:function(){}"
+         then I should get back a status of "400"
+
+    Scenario: prefix filtering does not execute regex search
+        Given "licensing.json" is in "foo" data_set with settings
+            | key                 | value |
+            | raw_queries_allowed | true  |
+         when I go to "/foo?filter_by_prefix=authority:.*"
+         then I should get back a status of "200"
+          and the JSON should have "0" results
+
+    Scenario: querying for data between two points and filtered by a key and prefix value
+        Given "licensing.json" is in "foo" data_set with settings
+            | key                 | value |
+            | raw_queries_allowed | true  |
+         when I go to "/foo?start_at=2012-12-13T00:00:02%2B00:00&end_at=2012-12-19T00:00:00%2B00:00&filter_by_prefix=type:succ"
+         then I should get back a status of "200"
+          and the JSON should have "1" results
+          and the "1st" result should be "{"_timestamp": "2012-12-13T01:01:01+00:00", "licence_name": "Temporary events notice", "interaction": "success", "authority": "Westminster", "type": "success", "_id": "1236"}"
+
+    Scenario: query does not convert to boolean with prefix filter
+        Given "dinosaurs.json" is in "lizards" data_set with settings
+            | key                 | value |
+            | raw_queries_allowed | true  |
+         when I go to "/lizards?filter_by_prefix=eats_people:true"
+         then I should get back a status of "200"
+          and the JSON should have "0" results
+
     Scenario: querying for more boolean data
         Given "dinosaurs.json" is in "lizards" data_set
          when I go to "/lizards?group_by=eats_people"

--- a/features/read_api/group.feature
+++ b/features/read_api/group.feature
@@ -69,6 +69,14 @@ Feature: grouping queries for read api
            and the "1st" result should have "values" with item "{"_start_at": "2013-03-18T00:00:00+00:00", "_end_at": "2013-03-25T00:00:00+00:00", "_count": 1.0}"
 
 
+    Scenario: grouping data by time period (week) and a name and filtered by a key and prefix value
+        Given "stored_timestamps_for_filtering.json" is in "weekly" data_set
+         when I go to "/weekly?period=week&group_by=name&filter_by_prefix=name:alph&start_at=2013-03-11T00:00:00Z&end_at=2013-03-25T00:00:00Z"
+         then I should get back a status of "200"
+           and the JSON should have "1" results
+           and the "1st" result should have "values" with item "{"_start_at": "2013-03-11T00:00:00+00:00", "_end_at": "2013-03-18T00:00:00+00:00", "_count": 2.0}"
+           and the "1st" result should have "values" with item "{"_start_at": "2013-03-18T00:00:00+00:00", "_end_at": "2013-03-25T00:00:00+00:00", "_count": 1.0}"
+
     Scenario: grouping data by time period (week) and a name that doesn't exist
         Given "stored_timestamps_for_filtering.json" is in "weekly" data_set
          when I go to "/weekly?period=week&group_by=wibble&start_at=2013-03-11T00:00:00Z&end_at=2013-03-25T00:00:00Z"


### PR DESCRIPTION
Add new filter_by_prefix parameter. This is similar to the existing
filter_by parameter, except that searches are anchored to the start of
the string.

The Mongo query is also constructed using 'find', but passed through as
{ 'pagePath': /^\\/housing-benefit.*/ } rather than { 'pagePath':
'/housing-benefit' }. Mongo will parse this as a regular expression
query.

We escape all strings passed into the filter using Python's re module.

The justification for this parameter is to support multi-part formats in
the info-frontend application - e.g. we would like to serve aggregate
statistics for the number of tickets submitted across all pages in
multi-part guides and smart answers. To do this with the existing
filter_by parameter would require a call to Backdrop for each page in
the guide or smart answer, and some of these formats have 30+ pages.