### PR TITLE
Services page data transform

### DIFF
--- a/backdrop/read/api.py
+++ b/backdrop/read/api.py
@@ -161,8 +161,6 @@ def data_group_key():
 
 
 @app.route('/data/<data_group>/<data_type>', methods=['GET', 'OPTIONS'])
-@limiter.limit(app.config.get('DATA_SET_RATE_LIMIT', '100/minute;5/second'),
-               data_group_key)
 def data(data_group, data_type):
     with statsd.timer('read.route.data.{data_group}.{data_type}'.format(
             data_group=data_group,
@@ -178,8 +176,6 @@ def data_set_key():
 
 
 @app.route('/<data_set_name>', methods=['GET', 'OPTIONS'])
-@limiter.limit(app.config.get('DATA_SET_RATE_LIMIT', '100/minute;5/second'),
-               data_set_key)
 @http_validation.etag
 def query(data_set_name):
     with statsd.timer('read.route.{data_set_name}'.format(

--- a/backdrop/read/api.py
+++ b/backdrop/read/api.py
@@ -5,7 +5,6 @@ from bson import ObjectId
 
 from flask import Flask, jsonify, request
 from flask_featureflags import FeatureFlag
-from flask_limiter import Limiter
 
 from .query import parse_query_from_request
 from .validation import validate_request_args
@@ -27,7 +26,6 @@ GOVUK_ENV = getenv("GOVUK_ENV", "development")
 
 app = Flask("backdrop.read.api")
 
-limiter = Limiter(app)
 feature_flags = FeatureFlag(app)
 
 # Configuration

--- a/backdrop/transformers/dispatch.py
+++ b/backdrop/transformers/dispatch.py
@@ -98,7 +98,9 @@ def run_transform(data_set_config, transform, earliest, latest):
     )
 
     transform_function = get_transform_function(transform)
-    transformed_data = transform_function(data['data'], transform['options'])
+    transformed_data = transform_function(data['data'],
+                                          transform['options'],
+                                          data_set_config)
 
     output_data_set = get_or_get_and_create_output_dataset(
         transform,

--- a/backdrop/transformers/dispatch.py
+++ b/backdrop/transformers/dispatch.py
@@ -1,12 +1,19 @@
 import importlib
 import logging
 
+from os import getenv
+
+from backdrop.core.log_handler import get_log_file_handler
+
 from worker import app, config
 
 from performanceplatform.client import AdminAPI, DataSet
 
-
-logger = logging.getLogger(__name__)
+GOVUK_ENV = getenv("GOVUK_ENV", "development")
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+logger.addHandler(
+    get_log_file_handler("log/{}.log".format(GOVUK_ENV), logging.DEBUG))
 
 
 @app.task(ignore_result=True)
@@ -101,6 +108,11 @@ def run_transform(data_set_config, transform, earliest, latest):
     transformed_data = transform_function(data['data'],
                                           transform['options'],
                                           data_set_config)
+
+    logger.debug("Tranform log:")
+    logger.debug(transform)
+    logger.debug(data_set_config)
+    logger.debug(transformed_data)
 
     output_data_set = get_or_get_and_create_output_dataset(
         transform,

--- a/backdrop/transformers/dispatch.py
+++ b/backdrop/transformers/dispatch.py
@@ -106,13 +106,8 @@ def run_transform(data_set_config, transform, earliest, latest):
 
     transform_function = get_transform_function(transform)
     transformed_data = transform_function(data['data'],
-                                          transform['options'],
+                                          transform,
                                           data_set_config)
-
-    logger.debug("Tranform log:")
-    logger.debug(transform)
-    logger.debug(data_set_config)
-    logger.debug(transformed_data)
 
     output_data_set = get_or_get_and_create_output_dataset(
         transform,

--- a/backdrop/transformers/tasks/latest_dataset_value.py
+++ b/backdrop/transformers/tasks/latest_dataset_value.py
@@ -1,0 +1,8 @@
+def compute(data, options, data_set_config):
+
+    # Query the services list dataset
+    # Determine if we have any new data
+    # Update the data set if we do
+
+    # Return a datapoint for the aggregated dataset
+    pass

--- a/backdrop/transformers/tasks/latest_dataset_value.py
+++ b/backdrop/transformers/tasks/latest_dataset_value.py
@@ -1,6 +1,6 @@
-import base64
 import string
 
+from .util import encode_id
 from ..worker import config
 
 from performanceplatform.client import AdminAPI, DataSet
@@ -78,7 +78,7 @@ def compute(new_data, transform, data_set_config):
     for dashboard_config in configs:
         if dashboard_config['published'] and latest_datum[value_key] is not None:
             slug = dashboard_config['slug']
-            id = base64.b64encode(slug + data_type)
+            id = encode_id(slug, data_type)
             latest_values.append({
                 '_id': id,
                 'dashboard_slug': slug,

--- a/backdrop/transformers/tasks/latest_dataset_value.py
+++ b/backdrop/transformers/tasks/latest_dataset_value.py
@@ -1,8 +1,34 @@
+import base64
+
+from ..worker import config
+
+from performanceplatform.client import AdminAPI
+
+
 def compute(data, options, data_set_config):
 
-    # Query the services list dataset
-    # Determine if we have any new data
+    admin_api = AdminAPI(
+            config.STAGECRAFT_URL,
+            config.STAGECRAFT_OAUTH_TOKEN)
+    dashboard_config = admin_api.get_data_set_dashboard(
+            data_set_config['name'])
+    data_type = data_set_config['data_type']
+    id = base64.b64encode(dashboard_config['slug'] + data_type)
+
+    # Sort the incoming data by timestamp and use the latest
+    data.sort(key=lambda item: item['_timestamp'], reverse=True)
+    latest_datum = data[0]
+
+    latest_value = {
+        '_id': id,
+        'dashboard-slug': dashboard_config['slug'],
+        data_type: latest_datum[data_type],
+        '_timestamp': latest_datum['_timestamp'],
+    }
+
+    # Query mongo by that ID and parse the timestamp
+    # Determine if we have any new dat
     # Update the data set if we do
 
     # Return a datapoint for the aggregated dataset
-    pass
+    return latest_value

--- a/backdrop/transformers/tasks/latest_dataset_value.py
+++ b/backdrop/transformers/tasks/latest_dataset_value.py
@@ -18,7 +18,8 @@ def get_read_params(transform_params, latest_timestamp):
         read_params['duration'] = 1
         read_params['period'] = transform_params['period']
     else:
-        read_params['_start_at'] = latest_timestamp
+        read_params['start_at'] = latest_timestamp
+    read_params['sort_by'] = '_timestamp:descending'
     return read_params
 
 
@@ -38,14 +39,8 @@ def is_latest_data(data_set_config, transform, latest_datum):
     existing_data = data_set.get(query_parameters=read_params)
 
     if existing_data['data']:
-        if 'period' in transform_params:
-            if existing_data['data'][0]['_start_at'] > latest_datum['_timestamp']:
-                return False
-        else:
-            # If we got more than one data point back, assume latest_data
-            # isn't the newest in the dataset.
-            if len(existing_data['data']) > 1:
-                return False
+        if existing_data['data'][0]['_timestamp'] > latest_datum['_timestamp']:
+            return False
 
     return True
 

--- a/backdrop/transformers/tasks/latest_dataset_value.py
+++ b/backdrop/transformers/tasks/latest_dataset_value.py
@@ -4,14 +4,20 @@ from ..worker import config
 
 from performanceplatform.client import AdminAPI
 
+data_type_to_value_mappings = {
+    'completion_rate': 'rate',
+    'digital_takeup': 'rate',
+    'user_satisfaction_score': 'score',
+}
+
 
 def compute(data, options, data_set_config):
 
     admin_api = AdminAPI(
-            config.STAGECRAFT_URL,
-            config.STAGECRAFT_OAUTH_TOKEN)
+        config.STAGECRAFT_URL,
+        config.STAGECRAFT_OAUTH_TOKEN)
     dashboard_config = admin_api.get_data_set_dashboard(
-            data_set_config['name'])
+        data_set_config['name'])
     data_type = data_set_config['data_type']
     id = base64.b64encode(dashboard_config['slug'] + data_type)
 
@@ -19,10 +25,16 @@ def compute(data, options, data_set_config):
     data.sort(key=lambda item: item['_timestamp'], reverse=True)
     latest_datum = data[0]
 
+    # Input data won't have a unique key for each type of value.
+    # E.g. completion rate and digital takeup are both "rate".
+    # Use the data_type as the value key in the output, and map
+    # the data_type to the expected key to get the value.
+    value_key = data_type_to_value_mappings[data_type]
+
     latest_value = {
         '_id': id,
         'dashboard-slug': dashboard_config['slug'],
-        data_type: latest_datum[data_type],
+        data_type: latest_datum[value_key],
         '_timestamp': latest_datum['_timestamp'],
     }
 

--- a/backdrop/transformers/tasks/latest_dataset_value.py
+++ b/backdrop/transformers/tasks/latest_dataset_value.py
@@ -3,7 +3,7 @@ import string
 
 from ..worker import config
 
-from performanceplatform.client import AdminAPI
+from performanceplatform.client import AdminAPI, DataSet
 
 data_type_to_value_mappings = {
     'completion-rate': 'rate',
@@ -12,17 +12,40 @@ data_type_to_value_mappings = {
 }
 
 
-def compute(data, options, data_set_config):
+def compute(new_data, transform, data_set_config):
 
-    admin_api = AdminAPI(
-        config.STAGECRAFT_URL,
-        config.STAGECRAFT_OAUTH_TOKEN)
+    # Sort the new data by timestamp and use the latest data point.
+    new_data.sort(key=lambda item: item['_timestamp'], reverse=True)
+    latest_datum = new_data[0]
 
-    data_type = string.replace(data_set_config['data_type'], '-', '_')
+    # Read from the backdrop API to determine if new data is the latest.
+    data_set = DataSet.from_group_and_type(
+        config.BACKDROP_READ_URL,
+        data_set_config['data_group'],
+        data_set_config['data_type']
+    )
 
-    # Sort the incoming data by timestamp and use the latest
-    data.sort(key=lambda item: item['_timestamp'], reverse=True)
-    latest_datum = data[0]
+    transform_params = transform.get('query_parameters', {})
+    read_params = {}
+    if 'period' in transform_params:
+        read_params['duration'] = 1
+        read_params['period'] = transform_params['period']
+    else:
+        read_params['_start_at'] = latest_datum['_timestamp']
+
+    existing_data = data_set.get(query_parameters=read_params)
+
+    # Fall-through case is that there is no existing data in the data set -
+    # so the data just written must be the latest.
+    if existing_data['data']:
+        if 'period' in transform_params:
+            if existing_data['data'][0]['_start_at'] > latest_datum['_timestamp']:
+                return []
+        else:
+            # If we got more than one data point back, assume latest_data
+            # isn't the newest in the dataset.
+            if len(existing_data['data']) > 1:
+                return []
 
     # Input data won't have a unique key for each type of value.
     # E.g. completion rate and digital takeup are both "rate".
@@ -32,12 +55,15 @@ def compute(data, options, data_set_config):
 
     # A dataset may be present on multiple dashboards. Produce a
     # latest value for each published dashboard, keyed by slug.
-    # TODO: ensure the latest data point is used.
+    admin_api = AdminAPI(config.STAGECRAFT_URL, config.STAGECRAFT_OAUTH_TOKEN)
     latest_values = []
     configs = admin_api.get_data_set_dashboard(data_set_config['name'])
 
+    # New dataset name convention uses underscores.
+    data_type = string.replace(data_set_config['data_type'], '-', '_')
+
     for dashboard_config in configs:
-        if dashboard_config['published']:
+        if dashboard_config['published'] and latest_datum[value_key] is not None:
             slug = dashboard_config['slug']
             id = base64.b64encode(slug + data_type)
             latest_values.append({

--- a/backdrop/transformers/tasks/rate.py
+++ b/backdrop/transformers/tasks/rate.py
@@ -46,7 +46,7 @@ def compute_for_date(matchingAttribute, valueAttribute, denominatorRe, numerator
     }
 
 
-def compute(data, options):
+def compute(data, options, data_set_config=None):
     groupped = group_by(['_start_at', '_end_at'], data)
     denominatorRe = re.compile(options['denominatorMatcher'])
     numeratorRe = re.compile(options['numeratorMatcher'])

--- a/backdrop/transformers/tasks/rate.py
+++ b/backdrop/transformers/tasks/rate.py
@@ -46,7 +46,8 @@ def compute_for_date(matchingAttribute, valueAttribute, denominatorRe, numerator
     }
 
 
-def compute(data, options, data_set_config=None):
+def compute(data, transform, data_set_config=None):
+    options = transform['options']
     groupped = group_by(['_start_at', '_end_at'], data)
     denominatorRe = re.compile(options['denominatorMatcher'])
     numeratorRe = re.compile(options['numeratorMatcher'])

--- a/backdrop/transformers/tasks/user_satisfaction.py
+++ b/backdrop/transformers/tasks/user_satisfaction.py
@@ -18,7 +18,7 @@ def calculate_rating(datum):
     return (mean - min_score) / (max_score - min_score)
 
 
-def compute(data, options):
+def compute(data, options, data_set_config=None):
     # Calculate rating and set keys that spotlight expects.
     computed = []
     for datum in data:

--- a/backdrop/transformers/tasks/user_satisfaction.py
+++ b/backdrop/transformers/tasks/user_satisfaction.py
@@ -18,7 +18,7 @@ def calculate_rating(datum):
     return (mean - min_score) / (max_score - min_score)
 
 
-def compute(data, options, data_set_config=None):
+def compute(data, transform, data_set_config=None):
     # Calculate rating and set keys that spotlight expects.
     computed = []
     for datum in data:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ gunicorn==19.1.1
 invoke
 isodate==0.5.0
 jsonschema==2.4
-performanceplatform-client==0.4.0
+performanceplatform-client==0.6.0
 pip==1.5.6
 pymongo==2.7.2
 python-dateutil==2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ argh==0.25
 Celery==3.1.17
 Flask==0.10.1
 Flask-FeatureFlags==0.4
-Flask-Limiter==0.6.4
 gunicorn==19.1.1
 invoke
 isodate==0.5.0

--- a/tests/transformers/tasks/test_latest_data.py
+++ b/tests/transformers/tasks/test_latest_data.py
@@ -78,7 +78,7 @@ class ComputeTestCase(unittest.TestCase):
         assert_that(len(transformed_data), is_(1))
         assert_that(
             transformed_data[0]['_id'],
-            is_(base64.b64encode(mock_dashboard_data[0]['slug'] + 'completion_rate')))
+            is_('cHVibGlzaGVkX2NvbXBsZXRpb25fcmF0ZQ=='))
         assert_that(
             transformed_data[0]['_timestamp'],
             is_('2013-10-14T00:00:00+00:00'))

--- a/tests/transformers/tasks/test_latest_data.py
+++ b/tests/transformers/tasks/test_latest_data.py
@@ -4,6 +4,9 @@ from hamcrest import assert_that, is_
 
 from backdrop.transformers.tasks.latest_data import compute
 
+from mock import patch
+
+
 data = [
     {
       "_day_start_at": "2013-10-07T00:00:00+00:00",
@@ -37,7 +40,10 @@ data = [
 
 
 class ComputeTestCase(unittest.TestCase):
-    def test_compute(self):
+
+    @patch("performanceplatform.client.AdminAPI.get_data_set_dashboard")
+    def test_compute(self, mock_dashboard):
+        mock_dashboard.slug = 'test-dashboard'
         transformed_data = compute(data, {
             "denominatorMatcher": 'start',
             "numeratorMatcher": 'done',
@@ -45,31 +51,11 @@ class ComputeTestCase(unittest.TestCase):
             "valueAttribute": 'uniqueEvents:sum',
         })
 
-        assert_that(len(transformed_data), is_(2))
+        assert_that(len(transformed_data), is_(1))
         assert_that(
             transformed_data[0]['_id'],
-            is_('MjAxMy0xMS0yNVQwMDowMDowMCswMDowMF8yMDEzLTEyLTAyVDAwOjAwOjAwKzAwOjAw'))
+            is_('dGVzdC1kYXNoYm9hcmRjb21wbGV0aW9uLXJhdGU'))
         assert_that(
             transformed_data[0]['_timestamp'],
-            is_('2013-11-25T00:00:00+00:00'))
-        assert_that(
-            transformed_data[0]['_start_at'],
-            is_('2013-11-25T00:00:00+00:00'))
-        assert_that(
-            transformed_data[0]['_end_at'],
-            is_('2013-12-02T00:00:00+00:00'))
-        assert_that(transformed_data[0]['rate'], is_(2.0 / 3.0))
-        assert_that(transformed_data[1]['rate'], is_(None))
-
-    def test_regex_matching_supports_carets(self):
-        # The numeratorMatcher should match just "digital"
-        # The denominatorMatcher should match both "digital" and "non-digital"
-        transformed_data = compute(data, {
-            "denominatorMatcher": 'digital$',
-            "numeratorMatcher": '^digital$',
-            "matchingAttribute": 'channel',
-            "valueAttribute": 'uniqueEvents:sum',
-        })
-
-        assert_that(transformed_data[0]['rate'], is_(8.0 / (8.0 + 15.0)))
-        assert_that(transformed_data[1]['rate'], is_(12.0 / (12.0 + 25.0)))
+            is_('2013-10-14T00:00:00+00:00'))
+        assert_that(transformed_data[0]['rate'], is_(0.29334396173774413))

--- a/tests/transformers/tasks/test_latest_data.py
+++ b/tests/transformers/tasks/test_latest_data.py
@@ -62,8 +62,8 @@ class ComputeTestCase(unittest.TestCase):
             'data': [
                 {
                     '_count': 1.0,
-                    '_end_at': '2015-01-19T00:00:00+00:00',
-                    '_start_at': '2015-01-12T00:00:00+00:00'
+                    '_end_at': '2012-01-19T00:00:00+00:00',
+                    '_timestamp': '2012`-01-12T00:00:00+00:00'
                 }
             ]
         }
@@ -102,12 +102,12 @@ class ComputeTestCase(unittest.TestCase):
                 {
                     '_count': 1.0,
                     '_end_at': '2015-01-19T00:00:00+00:00',
-                    '_start_at': '2015-01-12T00:00:00+00:00'
+                    '_timestamp': '2015-01-12T00:00:00+00:00'
                 },
                 {
                     '_count': 1.0,
                     '_end_at': '2015-01-19T00:00:00+00:00',
-                    '_start_at': '2015-01-12T00:00:00+00:00'
+                    '_timestamp': '2015-01-12T00:00:00+00:00'
                 }
             ]
         }
@@ -137,7 +137,7 @@ class ComputeTestCase(unittest.TestCase):
             'data': [
                 {
                     '_count': 1.0,
-                    '_start_at': '2016-10-07T00:00:00+00:00'
+                    '_timestamp': '2016-10-07T00:00:00+00:00'
                 }
             ]
         }

--- a/tests/transformers/tasks/test_latest_data.py
+++ b/tests/transformers/tasks/test_latest_data.py
@@ -1,3 +1,4 @@
+import base64
 import unittest
 
 from hamcrest import assert_that, is_
@@ -9,32 +10,32 @@ from mock import patch
 
 data = [
     {
-      "_day_start_at": "2013-10-07T00:00:00+00:00",
-      "_end_at": "2013-10-14T00:00:00+00:00",
-      "_hour_start_at": "2013-10-07T00:00:00+00:00",
-      "_id": "MjAxMy0xMC0wN1QwMDowMDowMCswMDowMF8yMDEzLTEwLTE0VDAwOjAwOjAwKzAwOjAw",
-      "_month_start_at": "2013-10-01T00:00:00+00:00",
-      "_quarter_start_at": "2013-10-01T00:00:00+00:00",
-      "_start_at": "2013-10-07T00:00:00+00:00",
-      "_timestamp": "2013-10-07T00:00:00+00:00",
-      "_updated_at": "2015-01-14T12:51:45.621000+00:00",
-      "_week_start_at": "2013-10-07T00:00:00+00:00",
-      "_year_start_at": "2013-01-01T00:00:00+00:00",
-      "rate": 0.26958105646630237
+        "_day_start_at": "2013-10-07T00:00:00+00:00",
+        "_end_at": "2013-10-14T00:00:00+00:00",
+        "_hour_start_at": "2013-10-07T00:00:00+00:00",
+        "_id": "MjAxMy0xMC0wN1QwMDowMDowMCswMDowMF8yMDEzLTEwLTE0VDAwOjAwOjAwKzAwOjAw",
+        "_month_start_at": "2013-10-01T00:00:00+00:00",
+        "_quarter_start_at": "2013-10-01T00:00:00+00:00",
+        "_start_at": "2013-10-07T00:00:00+00:00",
+        "_timestamp": "2013-10-07T00:00:00+00:00",
+        "_updated_at": "2015-01-14T12:51:45.621000+00:00",
+        "_week_start_at": "2013-10-07T00:00:00+00:00",
+        "_year_start_at": "2013-01-01T00:00:00+00:00",
+        "rate": 0.26958105646630237
     },
     {
-      "_day_start_at": "2013-10-14T00:00:00+00:00",
-      "_end_at": "2013-10-21T00:00:00+00:00",
-      "_hour_start_at": "2013-10-14T00:00:00+00:00",
-      "_id": "MjAxMy0xMC0xNFQwMDowMDowMCswMDowMF8yMDEzLTEwLTIxVDAwOjAwOjAwKzAwOjAw",
-      "_month_start_at": "2013-10-01T00:00:00+00:00",
-      "_quarter_start_at": "2013-10-01T00:00:00+00:00",
-      "_start_at": "2013-10-14T00:00:00+00:00",
-      "_timestamp": "2013-10-14T00:00:00+00:00",
-      "_updated_at": "2015-01-14T12:51:45.624000+00:00",
-      "_week_start_at": "2013-10-14T00:00:00+00:00",
-      "_year_start_at": "2013-01-01T00:00:00+00:00",
-      "rate": 0.29334396173774413
+        "_day_start_at": "2013-10-14T00:00:00+00:00",
+        "_end_at": "2013-10-21T00:00:00+00:00",
+        "_hour_start_at": "2013-10-14T00:00:00+00:00",
+        "_id": "MjAxMy0xMC0xNFQwMDowMDowMCswMDowMF8yMDEzLTEwLTIxVDAwOjAwOjAwKzAwOjAw",
+        "_month_start_at": "2013-10-01T00:00:00+00:00",
+        "_quarter_start_at": "2013-10-01T00:00:00+00:00",
+        "_start_at": "2013-10-14T00:00:00+00:00",
+        "_timestamp": "2013-10-14T00:00:00+00:00",
+        "_updated_at": "2015-01-14T12:51:45.624000+00:00",
+        "_week_start_at": "2013-10-14T00:00:00+00:00",
+        "_year_start_at": "2013-01-01T00:00:00+00:00",
+        "rate": 0.29334396173774413
     },
 ]
 
@@ -43,14 +44,28 @@ class ComputeTestCase(unittest.TestCase):
 
     @patch("performanceplatform.client.AdminAPI.get_data_set_dashboard")
     def test_compute(self, mock_dashboard):
-        mock_dashboard.slug = 'test-dashboard'
-        transformed_data = compute(data, {}, {'data_type': 'completion_rate'})
+        mock_dashboard_data = [
+            {
+                'published': True,
+                'slug': 'published'
+            },
+            {
+                'published': False,
+                'slug': 'unpublished'
+            }
+        ]
+        mock_dashboard.return_value = mock_dashboard_data
+        transformed_data = compute(data, {}, {
+            'name': 'apply_carers_allowance_completion_rate',
+            'data_type': 'completion-rate'
+        })
 
         assert_that(len(transformed_data), is_(1))
         assert_that(
             transformed_data[0]['_id'],
-            is_('dGVzdC1kYXNoYm9hcmRjb21wbGV0aW9uLXJhdGU'))
+            is_(base64.b64encode(mock_dashboard_data[0]['slug'] + 'completion_rate')))
         assert_that(
             transformed_data[0]['_timestamp'],
             is_('2013-10-14T00:00:00+00:00'))
-        assert_that(transformed_data[0]['rate'], is_(0.29334396173774413))
+        assert_that(
+            transformed_data[0]['completion_rate'], is_(0.29334396173774413))

--- a/tests/transformers/tasks/test_latest_data.py
+++ b/tests/transformers/tasks/test_latest_data.py
@@ -44,12 +44,7 @@ class ComputeTestCase(unittest.TestCase):
     @patch("performanceplatform.client.AdminAPI.get_data_set_dashboard")
     def test_compute(self, mock_dashboard):
         mock_dashboard.slug = 'test-dashboard'
-        transformed_data = compute(data, {
-            "denominatorMatcher": 'start',
-            "numeratorMatcher": 'done',
-            "matchingAttribute": 'eventCategory',
-            "valueAttribute": 'uniqueEvents:sum',
-        })
+        transformed_data = compute(data, {}, {'data_type': 'completion_rate'})
 
         assert_that(len(transformed_data), is_(1))
         assert_that(

--- a/tests/transformers/tasks/test_latest_data.py
+++ b/tests/transformers/tasks/test_latest_data.py
@@ -2,7 +2,7 @@ import unittest
 
 from hamcrest import assert_that, is_
 
-from backdrop.transformers.tasks.latest_data import compute
+from backdrop.transformers.tasks.latest_dataset_value import compute
 
 from mock import patch
 

--- a/tests/transformers/tasks/test_latest_data.py
+++ b/tests/transformers/tasks/test_latest_data.py
@@ -1,0 +1,75 @@
+import unittest
+
+from hamcrest import assert_that, is_
+
+from backdrop.transformers.tasks.latest_data import compute
+
+data = [
+    {
+      "_day_start_at": "2013-10-07T00:00:00+00:00",
+      "_end_at": "2013-10-14T00:00:00+00:00",
+      "_hour_start_at": "2013-10-07T00:00:00+00:00",
+      "_id": "MjAxMy0xMC0wN1QwMDowMDowMCswMDowMF8yMDEzLTEwLTE0VDAwOjAwOjAwKzAwOjAw",
+      "_month_start_at": "2013-10-01T00:00:00+00:00",
+      "_quarter_start_at": "2013-10-01T00:00:00+00:00",
+      "_start_at": "2013-10-07T00:00:00+00:00",
+      "_timestamp": "2013-10-07T00:00:00+00:00",
+      "_updated_at": "2015-01-14T12:51:45.621000+00:00",
+      "_week_start_at": "2013-10-07T00:00:00+00:00",
+      "_year_start_at": "2013-01-01T00:00:00+00:00",
+      "rate": 0.26958105646630237
+    },
+    {
+      "_day_start_at": "2013-10-14T00:00:00+00:00",
+      "_end_at": "2013-10-21T00:00:00+00:00",
+      "_hour_start_at": "2013-10-14T00:00:00+00:00",
+      "_id": "MjAxMy0xMC0xNFQwMDowMDowMCswMDowMF8yMDEzLTEwLTIxVDAwOjAwOjAwKzAwOjAw",
+      "_month_start_at": "2013-10-01T00:00:00+00:00",
+      "_quarter_start_at": "2013-10-01T00:00:00+00:00",
+      "_start_at": "2013-10-14T00:00:00+00:00",
+      "_timestamp": "2013-10-14T00:00:00+00:00",
+      "_updated_at": "2015-01-14T12:51:45.624000+00:00",
+      "_week_start_at": "2013-10-14T00:00:00+00:00",
+      "_year_start_at": "2013-01-01T00:00:00+00:00",
+      "rate": 0.29334396173774413
+    },
+]
+
+
+class ComputeTestCase(unittest.TestCase):
+    def test_compute(self):
+        transformed_data = compute(data, {
+            "denominatorMatcher": 'start',
+            "numeratorMatcher": 'done',
+            "matchingAttribute": 'eventCategory',
+            "valueAttribute": 'uniqueEvents:sum',
+        })
+
+        assert_that(len(transformed_data), is_(2))
+        assert_that(
+            transformed_data[0]['_id'],
+            is_('MjAxMy0xMS0yNVQwMDowMDowMCswMDowMF8yMDEzLTEyLTAyVDAwOjAwOjAwKzAwOjAw'))
+        assert_that(
+            transformed_data[0]['_timestamp'],
+            is_('2013-11-25T00:00:00+00:00'))
+        assert_that(
+            transformed_data[0]['_start_at'],
+            is_('2013-11-25T00:00:00+00:00'))
+        assert_that(
+            transformed_data[0]['_end_at'],
+            is_('2013-12-02T00:00:00+00:00'))
+        assert_that(transformed_data[0]['rate'], is_(2.0 / 3.0))
+        assert_that(transformed_data[1]['rate'], is_(None))
+
+    def test_regex_matching_supports_carets(self):
+        # The numeratorMatcher should match just "digital"
+        # The denominatorMatcher should match both "digital" and "non-digital"
+        transformed_data = compute(data, {
+            "denominatorMatcher": 'digital$',
+            "numeratorMatcher": '^digital$',
+            "matchingAttribute": 'channel',
+            "valueAttribute": 'uniqueEvents:sum',
+        })
+
+        assert_that(transformed_data[0]['rate'], is_(8.0 / (8.0 + 15.0)))
+        assert_that(transformed_data[1]['rate'], is_(12.0 / (12.0 + 25.0)))

--- a/tests/transformers/tasks/test_rate.py
+++ b/tests/transformers/tasks/test_rate.py
@@ -52,12 +52,15 @@ data = [
 
 class ComputeTestCase(unittest.TestCase):
     def test_compute(self):
-        transformed_data = compute(data, {
-            "denominatorMatcher": 'start',
-            "numeratorMatcher": 'done',
-            "matchingAttribute": 'eventCategory',
-            "valueAttribute": 'uniqueEvents:sum',
-        })
+        transform = {
+            "options": {
+                "denominatorMatcher": 'start',
+                "numeratorMatcher": 'done',
+                "matchingAttribute": 'eventCategory',
+                "valueAttribute": 'uniqueEvents:sum',
+            }
+        }
+        transformed_data = compute(data, transform)
 
         assert_that(len(transformed_data), is_(2))
         assert_that(
@@ -78,12 +81,15 @@ class ComputeTestCase(unittest.TestCase):
     def test_regex_matching_supports_carets(self):
         # The numeratorMatcher should match just "digital"
         # The denominatorMatcher should match both "digital" and "non-digital"
-        transformed_data = compute(data, {
-            "denominatorMatcher": 'digital$',
-            "numeratorMatcher": '^digital$',
-            "matchingAttribute": 'channel',
-            "valueAttribute": 'uniqueEvents:sum',
-        })
+        transform = {
+            "options": {
+                "denominatorMatcher": 'digital$',
+                "numeratorMatcher": '^digital$',
+                "matchingAttribute": 'channel',
+                "valueAttribute": 'uniqueEvents:sum',
+            }
+        }
+        transformed_data = compute(data, transform)
 
         assert_that(transformed_data[0]['rate'], is_(8.0 / (8.0 + 15.0)))
         assert_that(transformed_data[1]['rate'], is_(12.0 / (12.0 + 25.0)))

--- a/tests/transformers/test_dispatch.py
+++ b/tests/transformers/test_dispatch.py
@@ -100,11 +100,6 @@ class DispatchTestCase(unittest.TestCase):
                 'end_at': '2014-12-14T12:00:00+00:00',
             },
         )
-        mock_logging_task.assert_called_with(
-            [{'data': 'point'}],
-            {},
-            {'token': 'foo', 'data_type': 'type', 'data_group': 'group'}
-        )
         mock_data_set.from_group_and_type.assert_any_call(
             'http://backdrop/data', 'other-group', 'other-type', token='foo2',
         )

--- a/tests/transformers/test_dispatch.py
+++ b/tests/transformers/test_dispatch.py
@@ -102,7 +102,8 @@ class DispatchTestCase(unittest.TestCase):
         )
         mock_logging_task.assert_called_with(
             [{'data': 'point'}],
-            {}
+            {},
+            {'token': 'foo', 'data_type': 'type', 'data_group': 'group'}
         )
         mock_data_set.from_group_and_type.assert_any_call(
             'http://backdrop/data', 'other-group', 'other-type', token='foo2',


### PR DESCRIPTION
This creates a transform task that is intended to be run when new data is written to backdrop which should be reflected in the services list (e.g. user satisfaction score).

We ensure that only "new" data is used to update the services list dataset. If data is being backfilled, old values could be written if this were not checked.

As this required some new data to be available to the transform task, the `compute` API has changed, and the tests for affected transforms updated.