### PR TITLE
Remove the restriction on latest data

### DIFF
--- a/backdrop/transformers/tasks/latest_dataset_value.py
+++ b/backdrop/transformers/tasks/latest_dataset_value.py
@@ -20,7 +20,7 @@ def compute(new_data, transform, data_set_config):
 
     # Only continue if we are not back filling data.
     if not is_latest_data(data_set_config, transform, latest_datum):
-        return []
+        pass
 
     # Input data won't have a unique key for each type of value.
     # E.g. completion rate and digital takeup are both "rate".

--- a/tests/transformers/tasks/test_latest_data.py
+++ b/tests/transformers/tasks/test_latest_data.py
@@ -7,6 +7,8 @@ from backdrop.transformers.tasks.latest_dataset_value import compute
 
 from mock import patch, Mock
 
+from unittest.case import SkipTest
+
 
 data = [
     {
@@ -88,6 +90,7 @@ class ComputeTestCase(unittest.TestCase):
     @patch("performanceplatform.client.DataSet.from_group_and_type")
     @patch("performanceplatform.client.AdminAPI.get_data_set_dashboard")
     def test_compute_old_date_range(self, mock_dashboard, mock_dataset):
+        raise SkipTest('skipped until latest data restriction reinstated')
         mock_dashboard_data = [
             {
                 'published': True,
@@ -124,6 +127,7 @@ class ComputeTestCase(unittest.TestCase):
     @patch("performanceplatform.client.DataSet.from_group_and_type")
     @patch("performanceplatform.client.AdminAPI.get_data_set_dashboard")
     def test_compute_old_date_period(self, mock_dashboard, mock_dataset):
+        raise SkipTest('skipped until latest data restriction reinstated')
         mock_dashboard_data = [
             {
                 'published': True,


### PR DESCRIPTION
The initial services page migration is effectively a backfill, which
this latest data check is supposed to prevent. Remove this until we have
run the migration when we can re instate