### PR TITLE
Protect against empty dashboard list

### DIFF
--- a/backdrop/transformers/tasks/latest_transaction_explorer_values.py
+++ b/backdrop/transformers/tasks/latest_transaction_explorer_values.py
@@ -61,9 +61,9 @@ def _service_ids_with_latest_data(data):
 
 def _dashboard_configs_with_latest_data(data):
     for service_id, latest_data in _service_ids_with_latest_data(data):
-        dashboard_config = admin_api.get_dashboard_by_tx_id(service_id)[0]
-        if dashboard_config:
-            yield dashboard_config, latest_data
+        dashboard_configs = admin_api.get_dashboard_by_tx_id(service_id)
+        if dashboard_configs:
+            yield dashboard_configs[0], latest_data
 
 
 def _get_data_points_for_each_tx_metric(data, transform, data_set_config):

--- a/backdrop/transformers/tasks/latest_transaction_explorer_values.py
+++ b/backdrop/transformers/tasks/latest_transaction_explorer_values.py
@@ -13,12 +13,15 @@ REQUIRED_DATA_POINTS = [
     "total_cost",
 ]
 
-REQUIRED_FIELDS = [
-    "_timestamp",
+ADDITIONAL_FIELDS = [
     "end_at",
     "period",
     "service_id",
     "type"
+]
+
+REQUIRED_FIELDS = [
+    "_timestamp",
 ]
 
 admin_api = AdminAPI(
@@ -42,10 +45,16 @@ def _get_stripped_down_data_for_data_point_name_only(
     and all the REQUIRED_FIELDS and building up a new dict based on
     these key: value pairings
     """
-    all_fields = REQUIRED_FIELDS + [data_point_name]
+    required_fields = REQUIRED_FIELDS + [data_point_name]
     new_data = {}
-    for field in all_fields:
-        new_data[field] = latest_data_points[field]
+    for field in required_fields:
+        if field in latest_data_points:
+            new_data[field] = latest_data_points[field]
+        else:
+            return None
+    for field in ADDITIONAL_FIELDS:
+        if field in latest_data_points:
+            new_data[field] = latest_data_points[field]
     new_data['dashboard_slug'] = dashboard_config['slug']
     new_data['_id'] = encode_id(
         new_data['dashboard_slug'],
@@ -74,13 +83,14 @@ def _get_data_points_for_each_tx_metric(data, transform, data_set_config):
                 dashboard_config, latest_data, data_point_name)
             # we need to look at, for example,
             # digital-takeup on the output data set - tx not the only source.
-            if is_latest_data({'data_group': transform['output']['data-group'],
-                               'data_type': transform['output']['data-type']},
-                              transform,
-                              latest_datum,
-                              additional_read_params={
-                                  'filter_by': 'dashboard_slug:{}'.format(
-                                      latest_datum['dashboard_slug'])}):
+            if latest_datum and is_latest_data(
+                    {'data_group': transform['output']['data-group'],
+                     'data_type': transform['output']['data-type']},
+                    transform,
+                    latest_datum,
+                    additional_read_params={
+                        'filter_by': 'dashboard_slug:{}'.format(
+                            latest_datum['dashboard_slug'])}):
                 yield latest_datum
 
 

--- a/tests/transformers/fixtures/transactions_explorer_example_data.json
+++ b/tests/transformers/fixtures/transactions_explorer_example_data.json
@@ -78,5 +78,25 @@
         "service_id": "sorn-innit",
         "total_cost": 6203480.9399999995,
         "type": "seasonally-adjusted"
+    },
+    {
+        "_day_start_at": "2012-01-01T00:00:00+00:00",
+        "_hour_start_at": "2012-01-01T00:00:00+00:00",
+        "_id": "MjAxMi0wMS0wMSAwMDowMDowMDIwMTMtMDEtMDEgMDA6MDA6MDBiaXMtYW5udWFsLXJldHVybnM=",
+        "_month_start_at": "2012-01-01T00:00:00+00:00",
+        "_quarter_start_at": "2012-01-01T00:00:00+00:00",
+        "_timestamp": "2012-01-01T00:00:00+00:00",
+        "_updated_at": "2014-03-19T10:44:32.287000+00:00",
+        "_week_start_at": "2013-12-26T00:00:00+00:00",
+        "cost_per_transaction": 2.63,
+        "digital_cost_per_transaction": 2.36,
+        "digital_takeup": 0.9756123825537215,
+        "end_at": "2013-01-01T00:00:00+00:00",
+        "number_of_digital_transactions": 2301214,
+        "number_of_transactions": 2358738,
+        "period": "year",
+        "service_id": "something-without-a-dashboard",
+        "total_cost": 6203480.9399999995,
+        "type": "seasonally-adjusted"
     }
 ]

--- a/tests/transformers/fixtures/transactions_explorer_example_data.json
+++ b/tests/transformers/fixtures/transactions_explorer_example_data.json
@@ -12,7 +12,6 @@
         "digital_cost_per_transaction": 2.52,
         "digital_takeup": 0.965537995968002,
         "end_at": "2012-04-01T00:00:00+00:00",
-        "number_of_digital_transactions": 2184914,
         "number_of_transactions": 2262898,
         "period": "year",
         "service_id": "bis-annual-returns",

--- a/tests/transformers/tasks/test_latest_transaction_explorer_values.py
+++ b/tests/transformers/tasks/test_latest_transaction_explorer_values.py
@@ -117,16 +117,6 @@ data_to_post = [
         "type": "seasonally-adjusted"
     },
     {
-        "_id": encode_id('bis-returns', 'number_of_digital_transactions'),
-        "_timestamp": "2013-04-01T00:00:00+00:00",
-        "end_at": "2012-04-01T00:00:00+00:00",
-        "number_of_digital_transactions": 2184914,
-        "period": "year",
-        "service_id": "bis-annual-returns",
-        "dashboard_slug": "bis-returns",
-        "type": "seasonally-adjusted"
-    },
-    {
         "_id": encode_id('bis-returns', 'number_of_transactions'),
         "_timestamp": "2013-04-01T00:00:00+00:00",
         "end_at": "2012-04-01T00:00:00+00:00",
@@ -182,8 +172,8 @@ class ComputeTestCase(unittest.TestCase):
             'data-group': 'transactions-explorer',
             'data-type': 'spreadsheet'}})
 
+        assert_that(len(transformed_data), is_(11))
         assert_that(transformed_data, contains_inanyorder(*data_to_post))
-        assert_that(len(transformed_data), is_(12))
 
     @patch("performanceplatform.client.DataSet.from_group_and_type")
     @patch("performanceplatform.client.AdminAPI.get_dashboard_by_tx_id")


### PR DESCRIPTION
This ensures fixes small bugs with getting the latest transaction explorer data - when there is no dashboard for a service id and when data points are not present.

These second of these issues illustrates a problem however - should we fall back to earlier data if data is not present or null?