### PR TITLE
Handle multiple data points for a service id.

### DIFF
--- a/backdrop/transformers/tasks/latest_transaction_explorer_values.py
+++ b/backdrop/transformers/tasks/latest_transaction_explorer_values.py
@@ -80,18 +80,14 @@ def _service_ids_with_data(data):
 
 
 def _get_dashboard_config(service_id):
-    dashboard_configs = admin_api.get_dashboard_by_tx_id(service_id)
-    if dashboard_configs:
-        return dashboard_configs[0]
-    else:
-        return None
+    return admin_api.get_dashboard_by_tx_id(service_id)
 
 
 def _get_dashboard_configs_with_data(ids_with_data):
     dashboard_configs_with_data = []
     for service_id, data in ids_with_data:
-        dashboard_config = _get_dashboard_config(service_id)
-        if dashboard_config:
+        dashboard_configs = _get_dashboard_config(service_id)
+        for dashboard_config in dashboard_configs:
             dashboard_configs_with_data.append((dashboard_config, data))
     return dashboard_configs_with_data
 

--- a/tests/transformers/tasks/test_latest_transaction_explorer_values.py
+++ b/tests/transformers/tasks/test_latest_transaction_explorer_values.py
@@ -43,6 +43,28 @@ data_to_post = [
         "type": "quarterly"
     },
     {
+        "_id": encode_id(
+            'quarterly-nonsense2',
+            'digital_cost_per_transaction'),
+        "_timestamp": "2012-12-12T00:00:00+00:00",
+        "digital_cost_per_transaction": 2.36,
+        "end_at": "2013-01-01T00:00:00+00:00",
+        "period": "year",
+        "service_id": "service-with-quarterly-data",
+        "dashboard_slug": "quarterly-nonsense2",
+        "type": "quarterly"
+    },
+    {
+        "_id": encode_id('quarterly-nonsense2', 'digital_takeup'),
+        "_timestamp": "2012-12-12T00:00:00+00:00",
+        "digital_takeup": 0.9756123825537215,
+        "end_at": "2013-01-01T00:00:00+00:00",
+        "period": "year",
+        "service_id": "service-with-quarterly-data",
+        "dashboard_slug": "quarterly-nonsense2",
+        "type": "quarterly"
+    },
+    {
         "_id": encode_id('sorn', 'cost_per_transaction'),
         "_timestamp": "2013-04-01T00:00:00+00:00",
         "cost_per_transaction": 5.2,
@@ -166,9 +188,14 @@ bis_returns_dashboard_config = [{
     'slug': 'bis-returns'
 }]
 
-quarterly_data_dashboard_config = [{
-    'slug': 'quarterly-nonsense'
-}]
+quarterly_data_dashboard_config = [
+    {
+        'slug': 'quarterly-nonsense'
+    },
+    {
+        'slug': 'quarterly-nonsense2'
+    }
+]
 
 
 class ComputeTestCase(unittest.TestCase):
@@ -197,7 +224,7 @@ class ComputeTestCase(unittest.TestCase):
             'data-group': 'transactions-explorer',
             'data-type': 'spreadsheet'}})
 
-        assert_that(len(transformed_data), is_(13))
+        assert_that(len(transformed_data), is_(15))
         assert_that(transformed_data, contains_inanyorder(*data_to_post))
 
     @patch("performanceplatform.client.DataSet.from_group_and_type")


### PR DESCRIPTION
Just using the first dashboard was used as a hack to get things working
and then forgotten about. Having been reminded by failures we now add
data for each dashboard.

Api has been tested and it always returns lists.