### PR TITLE
Filter by id - there is > 1 data point per slug

### DIFF
--- a/backdrop/transformers/tasks/latest_transaction_explorer_values.py
+++ b/backdrop/transformers/tasks/latest_transaction_explorer_values.py
@@ -115,9 +115,12 @@ def _get_data_points_for_each_tx_metric(data, transform, data_set_config):
                      'data_type': transform['output']['data-type']},
                     transform,
                     datum,
+                    # filter by record id as this is a hash of dashboard_slug
+                    # and data_point_name and is therefore the important
+                    # identifier of newer data
                     additional_read_params={
-                        'filter_by': 'dashboard_slug:{}'.format(
-                            datum['dashboard_slug'])}):
+                        'filter_by': '_id:{}'.format(
+                            datum['_id'])}):
                 yield datum
 
 


### PR DESCRIPTION
Previous filtering by dasboard slug means it will not post if there is
ANY newer data point for that dashboard. This made sense when we posted
all data from a time regardless of nulls and so the latest timestamp of
one data point was representative of the latest data point for all the
others. This is no longer true as we now post the latest non null for a
dashboard slug.