### PR TITLE
Migration script change directory rather than failing

### DIFF
--- a/tools/replicate-db.sh
+++ b/tools/replicate-db.sh
@@ -12,8 +12,7 @@ if [ "$(hostname)" == "development-1" ]; then
 fi
 
 if [ "$(basename $(pwd))" != 'tools' ]; then
-    echo "This script should be run from the backdrop/tools directory!"
-    exit
+    cd $(dirname $0)
 fi
 
 


### PR DESCRIPTION
The initial services page migration is effectively a backfill, which this
latest data check is supposed to prevent. Remove this until we have run the
migration when we can re instate. Also skip tests and fix a pep8 issue