### PR TITLE
Ensure user sat records for incomplete periods not written

### DIFF
--- a/backdrop/transformers/tasks/user_satisfaction.py
+++ b/backdrop/transformers/tasks/user_satisfaction.py
@@ -1,9 +1,12 @@
 from .util import encode_id
+import datetime
+import pytz
+from dateutil import parser
 
 
 def calculate_rating(datum):
     # See
-    # https://github.com/alphagov/spotlight/blob/ca291ffcc86a5397003be340ec263a2466b72cfe/app/common/collections/user-satisfaction.js
+    # https://github.com/alphagov/spotlight/blob/ca291ffcc86a5397003be340ec263a2466b72cfe/app/common/collections/user-satisfaction.js  # noqa
     if not datum['total:sum']:
         return None
     min_score = 1
@@ -22,17 +25,22 @@ def compute(data, transform, data_set_config=None):
     # Calculate rating and set keys that spotlight expects.
     computed = []
     for datum in data:
-        computed.append({
-            '_id': encode_id(datum['_start_at'], datum['_end_at']),
-            '_timestamp': datum['_start_at'],
-            '_start_at': datum['_start_at'],
-            '_end_at': datum['_end_at'],
-            'rating_1': datum['rating_1:sum'],
-            'rating_2': datum['rating_2:sum'],
-            'rating_3': datum['rating_3:sum'],
-            'rating_4': datum['rating_4:sum'],
-            'rating_5': datum['rating_5:sum'],
-            'num_responses': datum['total:sum'],
-            'score': calculate_rating(datum),
-        })
+        time_now = datetime.datetime.now(pytz.UTC)
+        end_at = parser.parse(datum['_end_at']).astimezone(pytz.utc)
+        # do not add record if period represented by this record
+        # is not yet finished.
+        if end_at < time_now:
+            computed.append({
+                '_id': encode_id(datum['_start_at'], datum['_end_at']),
+                '_timestamp': datum['_start_at'],
+                '_start_at': datum['_start_at'],
+                '_end_at': datum['_end_at'],
+                'rating_1': datum['rating_1:sum'],
+                'rating_2': datum['rating_2:sum'],
+                'rating_3': datum['rating_3:sum'],
+                'rating_4': datum['rating_4:sum'],
+                'rating_5': datum['rating_5:sum'],
+                'num_responses': datum['total:sum'],
+                'score': calculate_rating(datum),
+            })
     return computed

--- a/tests/transformers/tasks/test_user_satisfaction.py
+++ b/tests/transformers/tasks/test_user_satisfaction.py
@@ -1,4 +1,5 @@
 import unittest
+from freezegun import freeze_time
 
 from hamcrest import assert_that, is_
 
@@ -40,7 +41,7 @@ data = [
         "total:sum": 10.0
     },
     {
-        "_count": 0.0,
+        "_count": 7.0,
         "_start_at": "2014-12-01T00:00:00+00:00",
         "_end_at": "2014-12-08T00:00:00+00:00",
         "rating_1:sum": None,
@@ -52,8 +53,20 @@ data = [
     },
     {
         "_count": 7.0,
-        "_start_at": "2014-12-01T00:00:00+00:00",
-        "_end_at": "2014-12-08T00:00:00+00:00",
+        "_start_at": "2014-12-08T00:00:00+00:00",
+        "_end_at": "2014-12-15T00:00:00+00:00",
+        "rating_1:sum": 0.0,
+        "rating_2:sum": 0.0,
+        "rating_3:sum": 0.0,
+        "rating_4:sum": 0.0,
+        "rating_5:sum": 0.0,
+        "total:sum": 0.0
+    },
+    # this should be excluded as not yet 7 days
+    {
+        "_count": 3.0,
+        "_start_at": "2014-12-15T00:00:00+00:00",
+        "_end_at": "2014-12-22T00:00:00+00:00",
         "rating_1:sum": 0.0,
         "rating_2:sum": 0.0,
         "rating_3:sum": 0.0,
@@ -65,13 +78,15 @@ data = [
 
 
 class UserSatisfactionTestCase(unittest.TestCase):
+    @freeze_time('2014, 12, 18 00:00:00')
     def test_compute_user_satisfaction(self):
         transformed_data = compute(data, {})
 
         assert_that(len(transformed_data), is_(5))
         assert_that(
             transformed_data[0]['_id'],
-            is_('MjAxNC0xMS0xMFQwMDowMDowMCswMDowMF8yMDE0LTExLTE3VDAwOjAwOjAwKzAwOjAw'))
+            is_("MjAxNC0xMS0xMFQwMDowMDowMCswMDowM"
+                "F8yMDE0LTExLTE3VDAwOjAwOjAwKzAwOjAw"))
         assert_that(
             transformed_data[0]['_timestamp'],
             is_('2014-11-10T00:00:00+00:00'))


### PR DESCRIPTION
Previously the transrom written daily by the update to customer
satisfaction datsets would cause an update to the latest period daily
until the period is complete. This mean periods without enough data for
a whole week being displayed on graphs and skewing this metric by
showing data supposedly for a week in the future.

We use end at to determine completeness as if data becomes more granular
in the future then the maximum _count may change.