### PR TITLE
Query for latest data inclusively.

### DIFF
--- a/backdrop/transformers/dispatch.py
+++ b/backdrop/transformers/dispatch.py
@@ -51,6 +51,7 @@ def get_query_parameters(transform, earliest, latest):
             query_parameters['start_at'] = earliest.isoformat()
             query_parameters['end_at'] = latest.isoformat()
     else:
+        query_parameters['inclusive'] = 'true'
         query_parameters['start_at'] = earliest.isoformat()
         query_parameters['end_at'] = latest.isoformat()
 

--- a/tests/transformers/test_dispatch.py
+++ b/tests/transformers/test_dispatch.py
@@ -98,6 +98,7 @@ class DispatchTestCase(unittest.TestCase):
                 'flatten': 'true',
                 'start_at': '2014-12-10T12:00:00+00:00',
                 'end_at': '2014-12-14T12:00:00+00:00',
+                'inclusive': 'true',
             },
         )
         mock_data_set.from_group_and_type.assert_any_call(


### PR DESCRIPTION
Currently when a spreadsheet of data with timestamps between, say, the 26/02/2015 and
01/02/2015 this represents 7 days. However, the inferred start and end
ats inferred from this for the subsequent transform are the 26th to the
1st. As these are interpreted exclusively by backdrop it will only get 6
days of data back until the next upload. If the next upload contains the
data for this first week again and the next week - 02/02/2015 to
07/02/2015 it will then perform another exclusive query for the 26th to
the 7th. This time though it will include the FULL first week and update the
existing data accordingly, however the second week will again be one day
short. This ensures that dates passed through from
the write api are interpreted inclusively which seems like the expected
behaviour.