### PR TITLE
Feature/bound periods when transforming

### DIFF
--- a/backdrop/transformers/tasks/user_satisfaction.py
+++ b/backdrop/transformers/tasks/user_satisfaction.py
@@ -1,7 +1,4 @@
 from .util import encode_id
-import datetime
-import pytz
-from dateutil import parser
 
 
 def calculate_rating(datum):
@@ -25,22 +22,17 @@ def compute(data, transform, data_set_config=None):
     # Calculate rating and set keys that spotlight expects.
     computed = []
     for datum in data:
-        time_now = datetime.datetime.now(pytz.UTC)
-        end_at = parser.parse(datum['_end_at']).astimezone(pytz.utc)
-        # do not add record if period represented by this record
-        # is not yet finished.
-        if end_at < time_now:
-            computed.append({
-                '_id': encode_id(datum['_start_at'], datum['_end_at']),
-                '_timestamp': datum['_start_at'],
-                '_start_at': datum['_start_at'],
-                '_end_at': datum['_end_at'],
-                'rating_1': datum['rating_1:sum'],
-                'rating_2': datum['rating_2:sum'],
-                'rating_3': datum['rating_3:sum'],
-                'rating_4': datum['rating_4:sum'],
-                'rating_5': datum['rating_5:sum'],
-                'num_responses': datum['total:sum'],
-                'score': calculate_rating(datum),
-            })
+        computed.append({
+            '_id': encode_id(datum['_start_at'], datum['_end_at']),
+            '_timestamp': datum['_start_at'],
+            '_start_at': datum['_start_at'],
+            '_end_at': datum['_end_at'],
+            'rating_1': datum['rating_1:sum'],
+            'rating_2': datum['rating_2:sum'],
+            'rating_3': datum['rating_3:sum'],
+            'rating_4': datum['rating_4:sum'],
+            'rating_5': datum['rating_5:sum'],
+            'num_responses': datum['total:sum'],
+            'score': calculate_rating(datum),
+        })
     return computed

--- a/tests/transformers/tasks/test_user_satisfaction.py
+++ b/tests/transformers/tasks/test_user_satisfaction.py
@@ -1,5 +1,4 @@
 import unittest
-from freezegun import freeze_time
 
 from hamcrest import assert_that, is_
 
@@ -61,24 +60,11 @@ data = [
         "rating_4:sum": 0.0,
         "rating_5:sum": 0.0,
         "total:sum": 0.0
-    },
-    # this should be excluded as not yet 7 days
-    {
-        "_count": 3.0,
-        "_start_at": "2014-12-15T00:00:00+00:00",
-        "_end_at": "2014-12-22T00:00:00+00:00",
-        "rating_1:sum": 0.0,
-        "rating_2:sum": 0.0,
-        "rating_3:sum": 0.0,
-        "rating_4:sum": 0.0,
-        "rating_5:sum": 0.0,
-        "total:sum": 0.0
     }
 ]
 
 
 class UserSatisfactionTestCase(unittest.TestCase):
-    @freeze_time('2014, 12, 18 00:00:00')
     def test_compute_user_satisfaction(self):
         transformed_data = compute(data, {})
 


### PR DESCRIPTION
The will limit the periods we request so that we don't try and request a period that is currently incomplete.

For example if we requesting weeks and we are currently mid week we should not be able to pull data and transform the current week. We should only request fully complete periods.

@jcbashdown it would be good if you could have a look at this at it should subsume the code that you wrote specifically for user_satisfaction.