### PR TITLE
Add detail to error message

### DIFF
--- a/backdrop/core/validation.py
+++ b/backdrop/core/validation.py
@@ -118,7 +118,7 @@ def validate_record_data(data):
                 '_end_at is not a valid datetime object')
 
         if key == '_id' and not value_is_valid_id(value):
-            return invalid('_id is not a valid id')
+            return invalid('_id "{0}" is not a valid id'.format(value))
 
     return valid()
 

--- a/tests/core/test_validation.py
+++ b/tests/core/test_validation.py
@@ -190,7 +190,7 @@ class TestValidateRecordData(unittest.TestCase):
             '_id': 'invalid id'
         })
         assert_that(validation_result,
-                    is_invalid_with_message("_id is not a valid id"))
+                    is_invalid_with_message("_id \"invalid id\" is not a valid id"))
 
     def test_objects_with_unrecognised_internal_keys_are_disallowed(self):
         validation_result = validate_record_data({


### PR DESCRIPTION
When receiving a large amount of data, it can be helpful for a client
to know which record caused the problem.

Added after request from @benilovj.