### PR TITLE
Allow syncing data to gov.uk dev vm

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,16 @@ Other parameters:
 
 ## Useful tools
 
-* Copy data from an environment to the local Backdrop database (should be run on your host machine): `cd tools && ./replicate-db.sh <youruser>@mongo-1.pp-preview`
+### Sync data from environment
+
+Copy data from an environment to the local Backdrop database (should be run on your host machine): `bash tools/replicate-db.sh mongo-1.pp-preview`
+
+You may need to setup your [ssh config](https://github.gds/pages/gds/opsmanual/2nd-line/technical-setup.html#ssh-config) correctly for this to work
+
+To sync to the govuk dev vm, you can pass `govuk_dev` as the 2nd argument to this script - 
+
+`bash tools/replicate-db.sh mongo-1.pp-preview govuk_dev`
+
 
 ## Emptying a dataset
 

--- a/tools/replicate-db.sh
+++ b/tools/replicate-db.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -e
 
+set -euo pipefail
+
 #
 # Replicate backdrop mongo db from a source host to a target host.
 # Useful to import data from the preview environment to the development

--- a/tools/replicate-db.sh
+++ b/tools/replicate-db.sh
@@ -63,6 +63,10 @@ if [ -z "$2" ]; then
     pushd ../../pp-puppet/
     vagrant ssh development-1 -c "cd /var/apps/backdrop/tools && mongorestore --drop ${DUMPDIR}"
     popd
+elif [ "$2" = 'govuk_dev' ]; then
+    pushd ../../puppet/development
+    vagrant ssh -c "cd /var/govuk/backdrop/tools && mongorestore --drop ${DUMPDIR}"
+    popd
 else
     mongorestore --drop -h $DESTINATION_HOST $DUMPDIR
 fi


### PR DESCRIPTION
As we move to gov.uk infrastructure, we will need to use the gov.uk dev vm
- allow this by passing govuk_dev as the destination host argument. Also
update the readme to be a little more verbose and include this argument.