### PR TITLE
Check that the user has supplied a bearer token

### DIFF
--- a/backdrop/write/validation.py
+++ b/backdrop/write/validation.py
@@ -23,8 +23,8 @@ def auth_header_is_valid(data_set, auth_header):
 
     request_token = extract_bearer_token(auth_header)
 
-    if request_token != data_set.get('bearer_token', None):
-        log.error("expected <%s> but was <%s>" % (
-            data_set['bearer_token'], request_token))
-        return False
-    return True
+    if request_token and request_token == data_set.get('bearer_token', None):
+        return True
+    log.error("expected <%s> but was <%s>" % (
+        data_set['bearer_token'], request_token))
+    return False

--- a/tests/write/test_flask_integration.py
+++ b/tests/write/test_flask_integration.py
@@ -46,6 +46,28 @@ class PostDataTestCase(unittest.TestCase):
         assert_that( response, is_unauthorized())
         assert_that( response, is_error_response())
 
+    @fake_data_set_exists("foo", bearer_token="")
+    def test_authorization_header_must_not_be_empty(self):
+        response = self.app.post(
+            '/foo',
+            data='[]',
+            headers=[('Authorization', 'Bearer')],
+        )
+
+        assert_that( response, is_unauthorized())
+        assert_that( response, is_error_response())
+
+    @fake_data_set_exists("foo", bearer_token=None)
+    def test_authorization_header_must_not_be_none(self):
+        response = self.app.post(
+            '/foo',
+            data='[]',
+            headers=[('Authorization', 'Bearer')],
+        )
+
+        assert_that( response, is_unauthorized())
+        assert_that( response, is_error_response())
+
     @fake_data_set_exists("foo", bearer_token="foo-bearer-token")
     def test_authorization_header_must_match_server_side_value(self):
         response = self.app.post(


### PR DESCRIPTION
Previously it was possible to pass this check when POSTing DELETEing etc
via the api and consquently make changes to data_sets without bearer
tokens. We do not have any of these in use however this is still a
problem.