### PR TITLE
Output latest data point even if None

### DIFF
--- a/backdrop/transformers/tasks/latest_transaction_explorer_values.py
+++ b/backdrop/transformers/tasks/latest_transaction_explorer_values.py
@@ -31,9 +31,8 @@ admin_api = AdminAPI(
 
 def _get_latest_data_point(data, data_point_name):
     def _use_data_point(data_point, name, ignore):
-        has_data = (name in data_point and data_point[name])
         should_not_be_ignored = (ignore != data_point['type'])
-        return has_data and should_not_be_ignored
+        return should_not_be_ignored
 
     name = data_point_name['name']
     ignore = data_point_name['ignore']
@@ -64,7 +63,7 @@ def _get_stripped_down_data_for_data_point_name_only(
         if field in latest_data_points:
             new_data[field] = latest_data_points[field]
         else:
-            return None
+            new_data[field] = None
     for field in ADDITIONAL_FIELDS:
         if field in latest_data_points:
             new_data[field] = latest_data_points[field]

--- a/tests/transformers/tasks/test_latest_transaction_explorer_values.py
+++ b/tests/transformers/tasks/test_latest_transaction_explorer_values.py
@@ -119,6 +119,16 @@ data_to_post = [
         "type": "seasonally-adjusted"
     },
     {
+        "_id": encode_id('sorn', 'number_of_transactions'),
+        '_timestamp': u'2013-04-01T00:00:00+00:00',
+        'period': u'year',
+        'end_at': u'2012-04-01T00:00:00+00:00',
+        'number_of_transactions': None,
+        'dashboard_slug': 'sorn',
+        'service_id': u'sorn-innit',
+        'type': u'seasonally-adjusted'
+    },
+    {
         "_id": encode_id('bis-returns', 'cost_per_transaction'),
         "_timestamp": "2013-04-01T00:00:00+00:00",
         "cost_per_transaction": 5.2,
@@ -150,9 +160,9 @@ data_to_post = [
     },
     {
         "_id": encode_id('bis-returns', 'number_of_digital_transactions'),
-        "_timestamp": "2012-12-12T00:00:00+00:00",
-        "end_at": "2013-01-01T00:00:00+00:00",
-        "number_of_digital_transactions": 2301214,
+        "_timestamp": "2013-04-01T00:00:00+00:00",
+        "end_at": "2012-04-01T00:00:00+00:00",
+        "number_of_digital_transactions": None,
         "period": "year",
         "service_id": "bis-annual-returns",
         "dashboard_slug": "bis-returns",
@@ -224,7 +234,7 @@ class ComputeTestCase(unittest.TestCase):
             'data-group': 'transactions-explorer',
             'data-type': 'spreadsheet'}})
 
-        assert_that(len(transformed_data), is_(15))
+        assert_that(len(transformed_data), is_(len(data_to_post)))
         assert_that(transformed_data, contains_inanyorder(*data_to_post))
 
     @patch("performanceplatform.client.DataSet.from_group_and_type")


### PR DESCRIPTION
In order to show as much data as possible
on the services page, we previously would
ignore later datapoints if the values were
None when creating the latest data dataset.

This modifies the transform to use the latest
datapoint, even if the value is None. This will
result in less data being shown on the services
page, but the data there will be fresher.