### PR TITLE
Json log should be at *.json.log not *.log.json

### DIFF
--- a/backdrop/core/log_handler.py
+++ b/backdrop/core/log_handler.py
@@ -42,7 +42,7 @@ def set_up_logging(app, env):
         get_log_file_handler("log/%s.log" % env, numeric_log_level)
     )
     logger.addHandler(
-        get_json_log_handler("log/%s.log.json" % env, app.name)
+        get_json_log_handler("log/%s.json.log" % env, app.name)
     )
     logger.setLevel(numeric_log_level)
     request_id_filter = RequestIdFilter()

--- a/tests/core/test_json_logging.py
+++ b/tests/core/test_json_logging.py
@@ -19,7 +19,7 @@ class TestJsonLogging(unittest.TestCase):
         log_handler.set_up_logging(self.app, 'json_test')
         self.logger.info('Writing out JSON formatted logs m8')
 
-        with open('log/json_test.log.json') as log_file:
+        with open('log/json_test.json.log') as log_file:
             data = json.loads(log_file.readlines()[-1])
 
         assert_that(data, has_entries({
@@ -31,5 +31,5 @@ class TestJsonLogging(unittest.TestCase):
         }))
 
         # Only remove file if assertion passes
-        os.remove('log/json_test.log.json')
+        os.remove('log/json_test.json.log')
         os.remove('log/json_test.log')


### PR DESCRIPTION
GOV.UK puppet will only pick up json logs when the path is
production.json.log not as it is at the moment.