### PR TITLE
Remove data group and type from statsd timer name

### DIFF
--- a/backdrop/read/api.py
+++ b/backdrop/read/api.py
@@ -160,11 +160,8 @@ def data_group_key():
 
 @app.route('/data/<data_group>/<data_type>', methods=['GET', 'OPTIONS'])
 def data(data_group, data_type):
-    with statsd.timer('read.route.data.{data_group}.{data_type}'.format(
-            data_group=data_group,
-            data_type=data_type)):
-        data_set_config = admin_api.get_data_set(data_group, data_type)
-        return fetch(data_set_config)
+    data_set_config = admin_api.get_data_set(data_group, data_type)
+    return fetch(data_set_config)
 
 
 def data_set_key():
@@ -176,10 +173,8 @@ def data_set_key():
 @app.route('/<data_set_name>', methods=['GET', 'OPTIONS'])
 @http_validation.etag
 def query(data_set_name):
-    with statsd.timer('read.route.{data_set_name}'.format(
-            data_set_name=data_set_name)):
-        data_set_config = admin_api.get_data_set_by_name(data_set_name)
-        return fetch(data_set_config)
+    data_set_config = admin_api.get_data_set_by_name(data_set_name)
+    return fetch(data_set_config)
 
 
 @crossdomain(origin='*')

--- a/backdrop/write/api.py
+++ b/backdrop/write/api.py
@@ -120,25 +120,22 @@ def write_by_group(data_group, data_type):
     Write by group/type
     e.g. POST https://BACKDROP/data/my-transaction-name/volumetrics
     """
-    with statsd.timer('write.route.data.{data_group}.{data_type}'.format(
-            data_group=data_group,
-            data_type=data_type)):
-        data_set_config = admin_api.get_data_set(data_group, data_type)
+    data_set_config = admin_api.get_data_set(data_group, data_type)
 
-        _validate_config(data_set_config)
-        _validate_auth(data_set_config)
+    _validate_config(data_set_config)
+    _validate_auth(data_set_config)
 
-        try:
-            data = listify_json(get_json_from_request(request))
-        except ValidationError as e:
-            return (jsonify(messages=[repr(e)]), 400)
-        errors = _append_to_data_set(data_set_config, data)
+    try:
+        data = listify_json(get_json_from_request(request))
+    except ValidationError as e:
+        return (jsonify(messages=[repr(e)]), 400)
+    errors = _append_to_data_set(data_set_config, data)
 
-        if errors:
-            return (jsonify(messages=errors), 400)
-        else:
-            trigger_transforms(data_set_config, data)
-            return jsonify(status='ok')
+    if errors:
+        return (jsonify(messages=errors), 400)
+    else:
+        trigger_transforms(data_set_config, data)
+        return jsonify(status='ok')
 
 
 @app.route('/data/<data_group>/<data_type>', methods=['PUT'])


### PR DESCRIPTION
These stats are taking up approximately 80GB of disk space, because
each data group and type combination will create a new whisper file. We
dont need to know in this much detail how long the endpoints are taking
to respond