### PR TITLE
Remove data group and type from statsd timer name

### DIFF
--- a/start-app.sh
+++ b/start-app.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -e
+export MONGO_REPLICA_SET=''
 
 VENV_DIR=~/.virtualenvs/$(basename $(cd $(dirname $0) && pwd -P))-$1-$2
 LOCK_DIR=./tmp-start


### PR DESCRIPTION
These stats are taking up approximately 80GB of disk space, because
each data group and type combination will create a new whisper file. We
dont need to know in this much detail how long the endpoints are taking
to respond