### PR TITLE
Format push api date timestamps utc

### DIFF
--- a/backdrop/core/data_set.py
+++ b/backdrop/core/data_set.py
@@ -84,16 +84,16 @@ class DataSet(object):
                 # doesn't change data, no need to return records
                 errors += validate_record_schema(record, self.config['schema'])
 
+        # Parse timestamps
+        records, timestamp_errors = separate_errors_and_records(
+            map(parse_timestamps, records))
+        errors += timestamp_errors
+
         # Add auto-id keys
         records, auto_id_errors = add_auto_ids(
             records,
             self.config.get('auto_ids', None))
         errors += auto_id_errors
-
-        # Parse timestamps
-        records, timestamp_errors = separate_errors_and_records(
-            map(parse_timestamps, records))
-        errors += timestamp_errors
 
         # Custom record validations
         # doesn't change data, no need to return records

--- a/backdrop/core/log_handler.py
+++ b/backdrop/core/log_handler.py
@@ -5,6 +5,7 @@ from flask import request
 
 
 class RequestIdFilter(logging.Filter):
+
     def filter(self, record):
         try:
             record.govuk_request_id = request.headers.get('Govuk-Request-Id')

--- a/backdrop/read/config/development.py
+++ b/backdrop/read/config/development.py
@@ -3,6 +3,6 @@ MONGO_HOSTS = ['localhost']
 MONGO_PORT = 27017
 LOG_LEVEL = "DEBUG"
 
-STAGECRAFT_URL = 'http://localhost:3103'
+STAGECRAFT_URL = 'http://stagecraft.dev.gov.uk'
 
 SIGNON_API_USER_TOKEN = 'development-oauth-access-token'

--- a/backdrop/write/config/development.py
+++ b/backdrop/write/config/development.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
     from development_environment_sample import *
 
-STAGECRAFT_URL = 'http://localhost:3103'
+STAGECRAFT_URL = 'http://stagecraft.dev.gov.uk'
 
 SIGNON_API_USER_TOKEN = 'development-oauth-access-token'
 

--- a/features/steps/write_api.py
+++ b/features/steps/write_api.py
@@ -82,7 +82,6 @@ def step(context, http_method, path):
         content_type="application/json",
         headers=_make_headers_from_context(context),
     )
-    print context.response.content
 
 
 @when('I {http_method} to "{path}" with a malformed authorization header')

--- a/features/steps/write_api.py
+++ b/features/steps/write_api.py
@@ -76,12 +76,15 @@ def step(context, http_method, path):
         'PUT': context.client.put
     }[http_method]
 
+    print http_function
+
     context.response = http_function(
         path,
         data=context.data_to_post,
         content_type="application/json",
         headers=_make_headers_from_context(context),
     )
+    print context.response
 
 
 @when('I {http_method} to "{path}" with a malformed authorization header')

--- a/features/steps/write_api.py
+++ b/features/steps/write_api.py
@@ -76,15 +76,13 @@ def step(context, http_method, path):
         'PUT': context.client.put
     }[http_method]
 
-    print http_function
-
     context.response = http_function(
         path,
         data=context.data_to_post,
         content_type="application/json",
         headers=_make_headers_from_context(context),
     )
-    print context.response
+    print context.response.text
 
 
 @when('I {http_method} to "{path}" with a malformed authorization header')

--- a/features/steps/write_api.py
+++ b/features/steps/write_api.py
@@ -82,7 +82,7 @@ def step(context, http_method, path):
         content_type="application/json",
         headers=_make_headers_from_context(context),
     )
-    print context.response.text
+    print context.response.content
 
 
 @when('I {http_method} to "{path}" with a malformed authorization header')

--- a/features/support/stagecraft.py
+++ b/features/support/stagecraft.py
@@ -33,6 +33,7 @@ class StagecraftService(object):
         @self.__app.route('/<path:path>')
         def catch_all(path):
             if path == '_is_fake_server_up':
+                print "YES!!!!"
                 return Response('Yes: {}'.format(os.getpid()), 200)
 
             path_and_query = path
@@ -76,6 +77,7 @@ class StagecraftService(object):
         if self.__proc is None:
             return False
         try:
+            print "TRYING TO GET FAKE SERVER"
             url = 'http://127.0.0.1:{}/_is_fake_server_up'.format(self.__port)
             return requests.get(url).status_code == 200
         except:

--- a/features/support/stagecraft.py
+++ b/features/support/stagecraft.py
@@ -60,6 +60,7 @@ class StagecraftService(object):
         print "START FAKE SERVER"
         if self.stopped():
             self.__proc = Process(target=self._run)
+            print "STARTING FAKE SERVER"
             self.__proc.start()
             wait_until(self.running)
 
@@ -80,7 +81,7 @@ class StagecraftService(object):
         if self.__proc is None:
             return False
         try:
-            print "TRYING TO GET FAKE SERVER"
+            print "FAKE SERVER RUNNING"
             url = 'http://127.0.0.1:{}/_is_fake_server_up'.format(self.__port)
             return requests.get(url).status_code == 200
         except:

--- a/features/support/stagecraft.py
+++ b/features/support/stagecraft.py
@@ -57,12 +57,14 @@ class StagecraftService(object):
         self.restart()
 
     def start(self):
+        print "START FAKE SERVER"
         if self.stopped():
             self.__proc = Process(target=self._run)
             self.__proc.start()
             wait_until(self.running)
 
     def stop(self):
+        print "STOP FAKE SERVER"
         if self.running():
             self.__proc.terminate()
             self.__proc.join()
@@ -70,6 +72,7 @@ class StagecraftService(object):
         wait_until(self.stopped)
 
     def restart(self):
+        print "RESTART FAKE SERVER"
         self.stop()
         self.start()
 
@@ -84,6 +87,7 @@ class StagecraftService(object):
             return False
 
     def stopped(self):
+        print "FAKE SERVER STOPPED"
         return not self.running()
 
     def _run(self):


### PR DESCRIPTION
Slight differences in the way the _timestamp cell is formatted (in
file uploads) results in duplicated data in the dataset.

What’s happening is this: _timestamp is listed as an auto_id for
the data set. All auto_id fields and values are joined together and
then base64 encoded and stored in the _id field.

AFTER the _id field has been created for the data record, the
_timestamp is parsed and converted to utc format.  This means that
the date format of the timestamp can differ from the date format of
the timestamp in the _id.

The _id is used as a unique key for the data set.
The same _timestamp with a different date format will generate a
different _id value and will added as a new row in backdrop.

The fix was just to move converting the _timestamp to utc format
to BEFORE the base64 encoded _id is generated.