### PR TITLE
Revert 6bbf31693cdda44e5ae49ccf02a10422564e4ee0

### DIFF
--- a/backdrop/core/data_set.py
+++ b/backdrop/core/data_set.py
@@ -84,16 +84,16 @@ class DataSet(object):
                 # doesn't change data, no need to return records
                 errors += validate_record_schema(record, self.config['schema'])
 
-        # Parse timestamps
-        records, timestamp_errors = separate_errors_and_records(
-            map(parse_timestamps, records))
-        errors += timestamp_errors
-
         # Add auto-id keys
         records, auto_id_errors = add_auto_ids(
             records,
             self.config.get('auto_ids', None))
         errors += auto_id_errors
+
+        # Parse timestamps
+        records, timestamp_errors = separate_errors_and_records(
+            map(parse_timestamps, records))
+        errors += timestamp_errors
 
         # Custom record validations
         # doesn't change data, no need to return records

--- a/tests/core/test_data_set.py
+++ b/tests/core/test_data_set.py
@@ -219,31 +219,6 @@ class TestDataSet_store(BaseDataSetTest):
         assert_that(add_period_keys_patch.called, is_(False))
         assert_that(save_record_patch.called, is_(False))
 
-    def test_store_parses_timestamp_to_utc_before_generating_auto_id(self):
-        self.setup_config({'auto_ids': ['_timestamp']})
-
-        expected_id = 'MjAxMi0xMi0xMiAwMDowMDowMCswMDowMA=='
-
-        self.data_set.store([{"_timestamp": "2012-12-12T00:00:00Z"}])
-
-        self.mock_storage.save_record.assert_called_with(
-            'test_data_set', match(has_entry('_id', expected_id)))
-
-        self.data_set.store([{"_timestamp": "2012-12-12T00:00:00+00:00"}])
-
-        self.mock_storage.save_record.assert_called_with(
-            'test_data_set', match(has_entry('_id', expected_id)))
-
-        self.data_set.store([{"_timestamp": "12/12/2012"}])
-
-        self.mock_storage.save_record.assert_called_with(
-            'test_data_set', match(has_entry('_id', expected_id)))
-
-        self.data_set.store([{"_timestamp": "12-12-2012 00:00:00"}])
-
-        self.mock_storage.save_record.assert_called_with(
-            'test_data_set', match(has_entry('_id', expected_id)))
-
 
 class TestDataSet_execute_query(BaseDataSetTest):
 


### PR DESCRIPTION
Reverts alphagov/backdrop#450

The fix we put in had an unintended side-effect. If users append new data to an existing spreadsheet, and then re-upload. As well as a new row being being created for the new data, new rows are created for the existing data. This is because the older data had primary keys containing timestamps in another date format, and this changed converts all timestamps to utc format before creating the primary key.