### PR TITLE
Format timestamp before creating id field

### DIFF
--- a/backdrop/core/log_handler.py
+++ b/backdrop/core/log_handler.py
@@ -5,6 +5,7 @@ from flask import request
 
 
 class RequestIdFilter(logging.Filter):
+
     def filter(self, record):
         try:
             record.govuk_request_id = request.headers.get('Govuk-Request-Id')

--- a/backdrop/core/records.py
+++ b/backdrop/core/records.py
@@ -58,6 +58,14 @@ def _generate_auto_id(record, auto_id_keys):
         str(record[key]) for key in auto_id_keys))
 
 
+def make_query_criteria_from_auto_ids(record, auto_id_keys):
+    auto_id_dict = {}
+    for key, value in record.iteritems():
+        if key in auto_id_keys:
+            auto_id_dict[key] = value
+    return auto_id_dict
+
+
 def parse_timestamps(record):
     """Parses a timestamp in a record
 

--- a/backdrop/core/storage/mongo.py
+++ b/backdrop/core/storage/mongo.py
@@ -144,6 +144,9 @@ class MongoStorageEngine(object):
         record['_updated_at'] = timeutils.now()
         self._collection(data_set_id).save(record)
 
+    def delete_record(self, data_set_id, record):
+        self._collection(data_set_id).remove(record)
+
     def execute_query(self, data_set_id, query):
         return map(convert_datetimes_to_utc,
                    self._execute_query(data_set_id, query))

--- a/tests/core/test_records.py
+++ b/tests/core/test_records.py
@@ -1,7 +1,8 @@
 from unittest import TestCase
-from hamcrest import assert_that, is_
+from hamcrest import assert_that, is_, equal_to
 from nose.tools import assert_raises
-from backdrop.core.records import _generate_auto_id
+from backdrop.core.records import _generate_auto_id, \
+    make_query_criteria_from_auto_ids
 from backdrop.core.errors import ValidationError
 
 
@@ -18,3 +19,19 @@ class TestRecords(TestCase):
             _generate_auto_id,
             {'foo': 1},
             ['bar'])
+
+    def test_make_query_criteria(self):
+        auto_id_keys = ['_timestamp', 'channel']
+        new_record = {
+            "_timestamp": "12-12-2012 00:00:00",
+            "count": 3,
+            "channel": "paper"
+        }
+
+        expected_query_criteria = {
+            "_timestamp": "12-12-2012 00:00:00",
+            "channel": "paper"
+        }
+
+        assert_that(make_query_criteria_from_auto_ids(
+            new_record, auto_id_keys), equal_to(expected_query_criteria))


### PR DESCRIPTION
Slight differences in the way the _timestamp cell is formatted (in file uploads)
results in duplicated data in the dataset.

What’s happening is this: _timestamp is listed as an auto_id for
the data set. All auto_id fields and values are joined together and
then base64 encoded and stored in the _id field.

AFTER the _id field has been created for the data record, the
_timestamp is parsed and converted to utc format. This means that
the date format of the timestamp can differ from the date format of
the timestamp in the _id.

The _id is used as a unique key for the data set.
The same _timestamp with a different date format will generate a
different _id value and will added as a new row in backdrop.

Users don't just upload new data or only the data they want to change.
Users also upload data by:
1) appending a new row to the spreadsheet and then re-uploading all
of the old data they have every time, expecting that the old data will
just be overwritten.
2) Keep the latest few rows in the spreadsheet, append the new data
to that, and then re-upload.

To handle all of these cases, the following changes were made:
1.  Move converting the _timestamp to utc format to BEFORE the
   base64 encoded _id is generated.
2. Get a dict of the auto_id fields and their values.
3. Search the existing dataset for a row that matches (regardless
   of the value of the _id field) and delete the row if found.
4. Finally insert a new row into the dataset

Pivotal: https://www.pivotaltracker.com/story/show/102895550

This PR replaces/updates revoked https://github.com/alphagov/backdrop/pull/450
