### PR TITLE
Change dev to match other envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ Copy data from an environment to the local Backdrop database (should be run on y
 
 You may need to setup your [ssh config](https://github.gds/pages/gds/opsmanual/2nd-line/technical-setup.html#ssh-config) correctly for this to work
 
-To sync to the govuk dev vm, you can pass `govuk_dev` as the 2nd argument to this script - 
+To sync to the govuk dev vm, you can pass `govuk_dev` as the 2nd argument to this script -
 
-`bash tools/replicate-db.sh mongo-1.pp-preview govuk_dev`
+`bash tools/replicate-db.sh performance-mongo-1.preview govuk_dev`
 
 
 ## Emptying a dataset
@@ -133,6 +133,12 @@ To process these tasks, you must run the worker - this can be done with the
 following command
 
 `celery worker -A backdrop.transformers.worker -l debug`
+
+
+## Troubleshooting
+
+The logs for RabbitMQ can be found in: `/var/log/rabbitmq/`
+If there are any problems running transforms, this should be the first place to look.
 
 
 

--- a/backdrop/core/log_handler.py
+++ b/backdrop/core/log_handler.py
@@ -5,6 +5,7 @@ from flask import request
 
 
 class RequestIdFilter(logging.Filter):
+
     def filter(self, record):
         try:
             record.govuk_request_id = request.headers.get('Govuk-Request-Id')

--- a/backdrop/transformers/config/development.py
+++ b/backdrop/transformers/config/development.py
@@ -1,4 +1,4 @@
-TRANSFORMER_AMQP_URL = 'amqp://transformer:notarealpw@localhost:5672/%2Ftransformations'
+TRANSFORMER_AMQP_URL = 'amqp://backdrop_write:backdrop_write@localhost:5672/%2Fbackdrop_write'
 STAGECRAFT_URL = 'http://localhost:3103'
 STAGECRAFT_OAUTH_TOKEN = 'development-oauth-access-token'
 BACKDROP_READ_URL = 'http://backdrop-read.dev.gov.uk/data'


### PR DESCRIPTION
The spike into Services page data anomalies (https://www.pivotaltracker.com/story/show/109073998) has uncovered that the configuration for transform in the development differs from that in preview, staging in production. This means that you can't just start backdrop and curl the transform end point update a transform data set.

In all of the other environments both backdrop write and transform use user backdrop_write and vhost /backdrop_write for the queue config.
In development, backdrop write uses user backdrop_write and vhost /backdrop_write for the queue config, but transforms uses user transformer and vhost /transformations.

To successfully trigger a transform in development with this set up I had to create the transformer user and /transformations vhost manually in rabbitmq.

To make life easier for future developers, the transform config has been changed to match backdrop_write. This change won't affect how transform run in the other environments.