### PR TITLE
Add service_id to datasets of type latest_dataset_value

### DIFF
--- a/backdrop/transformers/tasks/latest_dataset_value.py
+++ b/backdrop/transformers/tasks/latest_dataset_value.py
@@ -47,6 +47,7 @@ def compute(new_data, transform, data_set_config):
                 'dashboard_slug': slug,
                 data_type: latest_datum[value_key],
                 '_timestamp': latest_datum['_timestamp'],
+                'service_id': slug
             })
 
     return latest_values

--- a/tests/transformers/tasks/test_latest_dataset_value.py
+++ b/tests/transformers/tasks/test_latest_dataset_value.py
@@ -86,6 +86,8 @@ class ComputeTestCase(unittest.TestCase):
             is_('2013-10-14T00:00:00+00:00'))
         assert_that(
             transformed_data[0]['completion_rate'], is_(0.29334396173774413))
+        assert_that(
+            transformed_data[0]['service_id'], is_('published'))
 
     @patch("performanceplatform.client.DataSet.from_group_and_type")
     @patch("performanceplatform.client.AdminAPI.get_data_set_dashboard")


### PR DESCRIPTION
The import_dashboards.py script in Stagecraft (used for
importing Transactions Explorer data) expects to
find a service_id key in the service aggregates dataset.
This key was missed when this transform was produced and
is causing import_dashboards.py to fail.