### PR TITLE
Set the celery failover strategy to round-robin

### DIFF
--- a/backdrop/write/api.py
+++ b/backdrop/write/api.py
@@ -53,6 +53,8 @@ log_handler.set_up_audit_logging(app, GOVUK_ENV)
 app.url_map.converters["data_set"] = DataSetConverter
 
 celery_app = Celery(broker=app.config['TRANSFORMER_AMQP_URL'])
+app.config['BROKER_FAILOVER_STRATEGY'] = "round-robin"
+celery_app.conf.update(app.config)
 
 
 def _record_write_error(e):


### PR DESCRIPTION
We made a change to allow the broker url to accept a list of rabbitmq
nodes. When node 1 was taken down, the celery process did not connect to
the next node in the list.

The default failover strategy for kombu is round-robin, but we
believe that celery is overwriting this and setting it to none if the
failover strategy is not explictly configured in the application
config.