### PR TITLE
Data migration to remove empty summary records

### DIFF
--- a/tools/delete_empty_summary_records.js
+++ b/tools/delete_empty_summary_records.js
@@ -1,0 +1,13 @@
+/*
+    From the backdrop repository, run:
+    mongo tools/delete_empty_summary_records.js
+*/
+
+conn = new Mongo();
+db = conn.getDB("backdrop");
+
+printjson({"Record count before remove": db.transactional_services_summaries.count()})
+
+db.transactional_services_summaries.remove({"service_id": ""})
+
+printjson({"Record count after remove": db.transactional_services_summaries.count()})


### PR DESCRIPTION
Empty summary records are appearing in the transactional_services_summaries Mongo collection and are causing the transformation of these summary records into the service
aggregate records to fail.

We suspect the cause of these empty records are an empty row in a Google
spreadsheet which has been imported into the collection.

This script removes these empty records, which all have an empty service_id field.