### PR TITLE
Add patch to write api

### DIFF
--- a/backdrop/core/data_set.py
+++ b/backdrop/core/data_set.py
@@ -71,6 +71,12 @@ class DataSet(object):
         if not self.storage.data_set_exists(self.name):
             self.storage.create_data_set(self.name, self.config['capped_size'])
 
+    def patch(self, record_id, record):
+        if self.storage.find_record(self.name, record_id) is not None:
+            return self.storage.update_record(self.name, record_id, record)
+        else:
+            return 'No record found with id {}'.format(record_id)
+
     def empty(self):
         return self.storage.empty_data_set(self.name)
 

--- a/backdrop/core/storage/mongo.py
+++ b/backdrop/core/storage/mongo.py
@@ -144,6 +144,14 @@ class MongoStorageEngine(object):
         record['_updated_at'] = timeutils.now()
         self._collection(data_set_id).save(record)
 
+    def find_record(self, data_set_id, record_id):
+        return self._collection(data_set_id).find_one(record_id)
+
+    def update_record(self, data_set_id, record_id, record):
+        record['_updated_at'] = timeutils.now()
+        self._collection(data_set_id).update(
+            {"_id": record_id}, {"$set": record})
+
     def execute_query(self, data_set_id, query):
         return map(convert_datetimes_to_utc,
                    self._execute_query(data_set_id, query))

--- a/tests/core/test_data_set.py
+++ b/tests/core/test_data_set.py
@@ -220,6 +220,32 @@ class TestDataSet_store(BaseDataSetTest):
         assert_that(save_record_patch.called, is_(False))
 
 
+class TestDataSet_patch(BaseDataSetTest):
+    schema = {
+        "$schema": "http://json-schema.org/schema#",
+        "title": "Timestamps",
+        "type": "object",
+        "properties": {
+            "_timestamp": {
+                "description": "An ISO8601 formatted date time",
+                "type": "string",
+                "format": "date-time"
+            }
+        },
+        "required": ["_timestamp"]
+    }
+
+    def test_patching_a_simple_record(self):
+        self.data_set.patch('uuid', {'foo': 'bar'})
+        self.mock_storage.update_record.assert_called_with(
+            'test_data_set', 'uuid', {'foo': 'bar'})
+
+    def test_record_not_found(self):
+        self.mock_storage.find_record.return_value = None
+        result = self.data_set.patch('uuid', {'foo': 'bar'})
+        assert_that(result, is_('No record found with id uuid'))
+
+
 class TestDataSet_execute_query(BaseDataSetTest):
 
     def test_period_query_fails_when_weeks_do_not_start_on_monday(self):

--- a/tools/replicate-db.sh
+++ b/tools/replicate-db.sh
@@ -66,7 +66,7 @@ if [ -z "$2" ]; then
     vagrant ssh development-1 -c "cd /var/apps/backdrop/tools && mongorestore --drop ${DUMPDIR}"
     popd
 elif [ "$2" = 'govuk_dev' ]; then
-    pushd ../../govuk-puppet/development
+    pushd ../../govuk-puppet/development-vm
     vagrant ssh -c "cd /var/govuk/backdrop/tools && mongorestore --drop ${DUMPDIR}"
     popd
 else


### PR DESCRIPTION
Add a patch route to the Backdrop Write API to allow one or more values in a data set document to be updated e.g.

curl --request PATCH -H 'Content-type: application/json' -H 'Authorization: Bearer <bearer token>' http://10.1.1.254:3039/data/find-pension-contact-details/digital-take-up/<_id of document in a data set collection>' -d '{"count": 200}'

Multiple key-value pairs can be supplied via the -d argument