### PR TITLE
Add documentation from the Ops Manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ command
 curl -X PUT -d "[]" https://{backdrop_url}/data/<data-group>/<data-type> -H 'Authorization: Bearer <token-from-stagecraft>' -H 'Content-Type: application/json'
 ```
 
+## Transformers
+
+Transformers run as part of the `backdrop-transformer-procfile-worker` service.
+
+```
+sudo service backdrop-transformer-procfile-worker status
+```
+
 ## Triggering a transform manually
 
 A transform occurs when data is written to in Backdrop. The transform applies


### PR DESCRIPTION
We are moving documentation out of the Ops Manual - this commit adds the
documentation about backdrop from the Ops Manual to this repo.

[Trello card](https://trello.com/c/5x8NHLhf/40-merge-opsmanual-into-developer-docs)