### PR TITLE
[#159387351] Fix missing celery config for write api.

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -20,6 +20,9 @@ applications:
     services:
       - redis
       - backdrop-db
+    env:
+      BACKDROP_BROKER_SSL_CERT_REQS: CERT_NONE
+      CELERY_CONFIG_MODULE: backdrop.celeryconfig
 
   - name: performance-platform-backdrop-celery-worker
     <<: *defaults


### PR DESCRIPTION
The celery configuration was missing from the write api app and so every
request that triggered a task in celery would hang / timeout / return an
http 502. This restores said config.